### PR TITLE
gregbob: add unrealircd (irc.gregbob.net)

### DIFF
--- a/clusters/cluster0/kubernetes/apps/gregbob/gregbob/irc/configmap.yaml
+++ b/clusters/cluster0/kubernetes/apps/gregbob/gregbob/irc/configmap.yaml
@@ -1,0 +1,102 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: irc-config
+  namespace: gregbob
+  labels:
+    app: irc
+    app.kubernetes.io/name: irc
+    app.kubernetes.io/component: config
+data:
+  unrealircd.conf: |
+    # Minimal UnrealIRCd 6 config for a single-server homelab network.
+    # The IRCD listens on plaintext port 6667 (TCP).
+    #
+    # NOTE on TLS/ingress: an IRC daemon is a TCP protocol, so it cannot ride
+    # a gateway.networking.k8s.io HTTPRoute. Reach it by flipping irc-service
+    # to `type: LoadBalancer` (MetalLB) and using that IP:port 6667. The
+    # HTTPRoute in this app is for parity / a future web bridge only.
+
+    # Load the default cloaking module:
+    loadmodule "cloak_sha256";
+
+    # Server identity (me block):
+    me {
+    	name "irc.gregbob.net";
+    	info "gregbob.net IRC Server";
+    	sid "001";
+    }
+
+    # /ADMIN block:
+    admin {
+    	"Greg";
+    	"gregbob";
+    	"greg@gregbob.net";
+    }
+
+    # Connection classes:
+    class clients
+    {
+    	pingfreq 90;
+    	maxclients 1000;
+    	sendq 200k;
+    	recvq 8000;
+    }
+
+    class opers
+    {
+    	pingfreq 90;
+    	maxclients 50;
+    	sendq 1M;
+    	recvq 8000;
+    }
+
+    # Allow everyone, 3 connections per IP:
+    allow {
+    	mask *;
+    	class clients;
+    	maxperip 3;
+    }
+
+    # Listen: plaintext IRC (the port the Services forward to):
+    listen {
+    	ip *;
+    	port 6667;
+    }
+
+    # Log to a file in the container's working dir (UnrealIRCd has no stdout
+    # log destination; use `kubectl exec -it <pod> -- /app/unrealircd/bin/unrealircd -r`
+    # to tail it). The image runs as `unreal`, which owns /ircd, so this is writable.
+    log {
+    	source {
+    		all;
+    		!debug;
+    	}
+    	destination {
+    		file "ircd.log" { maxsize 10M; }
+    	}
+    }
+
+    set {
+    	network-name 		"gregbobnet";
+    	default-server 		"irc.gregbob.net";
+    	services-server 	"irc.gregbob.net";
+    	stats-server 		"irc.gregbob.net";
+    	help-channel 		"#help";
+
+    	/* Cloak keys: regenerate with `unrealircdctl gencloak`. */
+    	cloak-keys {
+    		"r0Ca1AvIh3qMQuQuw2ddLxPDm0ci3mXRweobp8LQyjNhRoj6HDW6Z2P6LfQZ9i1rLVjvj7HoqQWAmyF2";
+    		"OJE3XCOTusNjOfsmkNIWfYZ6LZHGST280rGhCFu2JePns1Z1BGSLTgOvzwY3E0jv1NITPkUceKGp7XkP";
+    		"jjpATPYmULVhAOy5fJ0bJtH8xML1GdIjfzr41JQUhwgRgRsbgisSt40IhfWUn5wmatfHrI4Fb2lD1wkw";
+    	}
+    }
+
+    set {
+    	kline-address 'greg@gregbob.net';
+    	modes-on-connect "+ixw";
+    	modes-on-oper "+xws";
+    	modes-on-join "+nt";
+    	oper-auto-join "#opers";
+    	maxchannelsperuser 10;
+    }

--- a/clusters/cluster0/kubernetes/apps/gregbob/gregbob/irc/deployment.yaml
+++ b/clusters/cluster0/kubernetes/apps/gregbob/gregbob/irc/deployment.yaml
@@ -1,0 +1,44 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  labels:
+    app: irc
+  name: irc
+  namespace: gregbob
+spec:
+  # Single server: UnrealIRCd keeps all channel/global state in memory.
+  # Do NOT scale above 1 without introducing a server-link topology.
+  replicas: 1
+  selector:
+    matchLabels:
+      app: irc
+  template:
+    metadata:
+      labels:
+        app: irc
+    spec:
+      containers:
+        - name: irc
+          image: ircd/unrealircd:latest
+          imagePullPolicy: Always
+          ports:
+            - name: irc
+              containerPort: 6667
+              protocol: TCP
+          volumeMounts:
+            - name: config
+              mountPath: /ircd/unrealircd.conf
+              subPath: unrealircd.conf
+              readOnly: true
+          resources:
+            requests:
+              memory: 64Mi
+              cpu: 20m
+            limits:
+              memory: 256Mi
+              cpu: 500m
+      volumes:
+        - name: config
+          configMap:
+            name: irc-config
+      terminationGracePeriodSeconds: 30

--- a/clusters/cluster0/kubernetes/apps/gregbob/gregbob/irc/irc-route.yaml
+++ b/clusters/cluster0/kubernetes/apps/gregbob/gregbob/irc/irc-route.yaml
@@ -1,0 +1,20 @@
+---
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata:
+  name: irc
+  namespace: gregbob
+spec:
+  hostnames:
+  - irc.gregbob.net
+  parentRefs:
+  - name: wildcard-gregbob-net
+    namespace: network
+  rules:
+  - backendRefs:
+    - name: irc-service
+      port: 6667
+    matches:
+    - path:
+        type: PathPrefix
+        value: /

--- a/clusters/cluster0/kubernetes/apps/gregbob/gregbob/irc/service.yaml
+++ b/clusters/cluster0/kubernetes/apps/gregbob/gregbob/irc/service.yaml
@@ -1,0 +1,20 @@
+kind: Service
+apiVersion: v1
+metadata:
+  name: irc-service
+  namespace: gregbob
+  # To expose the IRC daemon directly over TCP (e.g. for irc clients), set
+  # `type: LoadBalancer` and allocate an IP from a MetalLB pool via the
+  # address-pool annotation (MetalLB IPs are a scarce resource here):
+  # annotations:
+  #   metallb.universe.tf/address-pool: "worker-01ip"
+spec:
+  selector:
+    app: irc
+  type: ClusterIP
+  ports:
+    - name: irc
+      protocol: TCP
+      port: 6667
+      targetPort: 6667
+  # type: LoadBalancer

--- a/clusters/cluster0/kubernetes/apps/gregbob/gregbob/ks.yaml
+++ b/clusters/cluster0/kubernetes/apps/gregbob/gregbob/ks.yaml
@@ -78,3 +78,23 @@ spec:
   interval: 3m
   retryInterval: 1m
   timeout: 2m
+---
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: &app irc
+  namespace: flux-system
+spec:
+  targetNamespace: gregbob
+  commonMetadata:
+    labels:
+      app.kubernetes.io/name: *app
+  path: ./clusters/cluster0/kubernetes/apps/gregbob/gregbob/irc/
+  prune: true
+  sourceRef:
+    kind: GitRepository
+    name: flux-system
+  wait: false
+  interval: 3m
+  retryInterval: 1m
+  timeout: 2m


### PR DESCRIPTION
Adds an **UnrealIRCd 6** IRC server to the `gregbob` namespace, following the per-app Flux `Kustomization` convention.

## What's here
- **Deployment** (`irc`) - pulls `ircd/unrealircd:latest` (v6.2.5, the actively-maintained official image built from the [unrealircd source](https://github.com/unrealircd/unrealircd)). Single replica (IRC state is in-memory; scale only with a server-link topology).
- **ConfigMap** (`irc-config`) - a minimal single-server `unrealircd.conf` (network `gregbobnet`, server `irc.gregbob.net`, sid `001`, plaintext listen on `6667`, fresh cloaking keys), mounted read-only at `/ircd/unrealircd.conf` (the image's working dir).
- **Service** (`irc-service`, ClusterIP :6667) - the HTTPRoute backend. Commented toggle to flip to `type: LoadBalancer` + MetalLB `address-pool` to actually expose the IRC daemon over TCP.
- **HTTPRoute** (`irc.gregbob.net` -> `wildcard-gregbob-net` gateway in `network`) - matches the pattern of every other gregbob.net subdomain.
- **`ks.yaml`** - new `irc` Kustomization registered alongside art/blog/landing/resume.

## Protocol caveat (read before merging)
UnrealIRCd is a **TCP** IRC daemon, not an HTTP service. The requested `HTTPRoute` is created exactly as asked and is valid, but an HTTP listener **cannot** speak IRC - real clients won't be able to connect through it. To make the server actually reachable you need one of:
1. **Recommended:** set `irc-service` to `type: LoadBalancer` with a MetalLB pool IP, then connect clients to `IP:6667`.
2. Add a TCP-capable gateway (e.g. an Envoy `TCPRoute` / `GRPCRoute`) - the current agentgateway GatewayClass here only exposes HTTP/HTTPS listeners.

## Validated
- `kubectl kustomize clusters/cluster0/kubernetes/apps/gregbob` renders clean (YAML + reference checks pass).
- Cross-checked: ConfigMap name <-> Deployment volume, listen port <-> containerPort <-> Service targetPort <-> HTTPRoute backend port, selector <-> pod labels.
- Fixed a would-be crashloop: UnrealIRCd has **no `stdout` log destination** (only `file`/syslog), so logs go to `ircd.log` in the container's working dir.

Flux tracks `main`; nothing reconciles until this is merged.
