### PR TITLE
matrix: add continuwuity homeserver + sable client

### DIFF
--- a/clusters/cluster0/kubernetes/apps/matrix/continuwuity/app/continuwuity-credentials.yaml
+++ b/clusters/cluster0/kubernetes/apps/matrix/continuwuity/app/continuwuity-credentials.yaml
@@ -1,0 +1,20 @@
+apiVersion: external-secrets.io/v1
+kind: ExternalSecret
+metadata:
+    name: continuwuity-credentials
+    namespace: matrix
+spec:
+    secretStoreRef:
+        kind: ClusterSecretStore
+        name: onepassword-connect
+    target:
+        creationPolicy: Owner
+    data:
+        - secretKey: token
+          remoteRef:
+            key: continuwuity-credentials
+            property: token
+        - secretKey: CONDUWUIT_EMERGENCY_PASSWORD
+          remoteRef:
+            key: continuwuity-credentials
+            property: CONDUWUIT_EMERGENCY_PASSWORD

--- a/clusters/cluster0/kubernetes/apps/matrix/continuwuity/app/continuwuity-route.yaml
+++ b/clusters/cluster0/kubernetes/apps/matrix/continuwuity/app/continuwuity-route.yaml
@@ -1,0 +1,27 @@
+---
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata:
+  name: continuwuity
+  namespace: matrix
+spec:
+  hostnames:
+    - matrix.gregbob.net
+  parentRefs:
+    - name: wildcard-gregbob-net
+      namespace: network
+  rules:
+    - matches:
+        - path:
+            type: PathPrefix
+            value: /_matrix
+      backendRefs:
+        - name: continuwuity-service
+          port: 8080
+    - matches:
+        - path:
+            type: PathPrefix
+            value: /_continuwuity/
+      backendRefs:
+        - name: continuwuity-service
+          port: 8080

--- a/clusters/cluster0/kubernetes/apps/matrix/continuwuity/app/continuwuity-service.yaml
+++ b/clusters/cluster0/kubernetes/apps/matrix/continuwuity/app/continuwuity-service.yaml
@@ -1,0 +1,13 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: continuwuity-service
+  namespace: matrix
+spec:
+  selector:
+    app: continuwuity
+  ports:
+    - name: uwu-port
+      port: 8080
+      protocol: TCP
+      targetPort: 8080

--- a/clusters/cluster0/kubernetes/apps/matrix/continuwuity/app/continuwuity-statefulset.yaml
+++ b/clusters/cluster0/kubernetes/apps/matrix/continuwuity/app/continuwuity-statefulset.yaml
@@ -1,0 +1,152 @@
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  labels:
+    app: continuwuity
+  name: continuwuity
+  namespace: matrix
+spec:
+  serviceName: continuwuity-service
+  replicas: 1
+  updateStrategy:
+    type: RollingUpdate
+  template:
+    metadata:
+      labels:
+        app: continuwuity
+    spec:
+      securityContext:
+        runAsUser: 1000
+        runAsGroup: 1000
+        fsGroup: 1000
+        seccompProfile:
+          type: RuntimeDefault
+      automountServiceAccountToken: false
+      enableServiceLinks: false
+      affinity:
+        nodeAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            nodeSelectorTerms:
+              - matchExpressions:
+                  - key: kubernetes.io/hostname
+                    operator: In
+                    values:
+                      - worker-01
+      containers:
+        - image: ghcr.io/continuwuity/continuwuity:main@sha256:665bbe89280e00a6cb9ff1a978bc17c8be994701c8c33c558f3af121213ca46b
+          imagePullPolicy: Always
+          name: continuwuity
+          env:
+            - name: CONTINUWUITY_PORT
+              value: "8080"
+            - name: CONTINUWUITY_DATABASE_PATH
+              value: "/data"
+            - name: CONTINUWUITY_DATABASE_BACKUP_PATH
+              value: "/backup"
+            - name: CONTINUWUITY_DATABASE_BACKUPS_TO_KEEP
+              value: "1"
+            - name: CONTINUWUITY_ROCKSDB_PARALLELISM_THREADS
+              value: "4"
+            - name: CONTINUWUITY_QUERY_TRUSTED_KEY_SERVERS_FIRST
+              value: "false"
+            - name: CONTINUWUITY_QUERY_TRUSTED_KEY_SERVERS_FIRST_ON_JOIN
+              value: "false"
+            # - name: CONTINUWUITY_FORBIDDEN_REMOTE_SERVER_NAMES
+            #   value: |
+            #     ["matrix.org"]
+            # - name: CONTINUWUITY_FORBIDDEN_REMOTE_ROOM_DIRECTORY_SERVER_NAMES
+            #   value: |
+            #     ["matrix.org"]
+            # - name: CONTINUWUITY_URL_PREVIEW_DOMAIN_EXPLICIT_DENYLIST
+            #   value: |
+            #     ["matrix.org"]
+            - name: CONTINUWUITY_SERVER_NAME
+              value: "gregbob.net"
+            - name: CONTINUWUITY_WELL_KNOWN__CLIENT
+              value: "https://matrix.gregbob.net"
+            - name: CONTINUWUITY_WELL_KNOWN__SERVER
+              value: "matrix.gregbob.net:443"
+            - name: CONTINUWUITY_MAX_REQUEST_SIZE
+              value: "1280000000"
+            - name: CONTINUWUITY_ALLOW_REGISTRATION
+              value: "true"
+            - name: CONTINUWUITY_REGISTRATION_TOKEN
+              valueFrom:
+                secretKeyRef:
+                  name: continuwuity-credentials
+                  key: token
+            # - name: CONTINUWUITY_EMERGENCY_PASSWORD
+            #   valueFrom:
+            #     secretKeyRef:
+            #       name: continuwuity-credentials
+            #       key: CONDUWUIT_EMERGENCY_PASSWORD
+            - name: CONTINUWUITY_ALLOW_FEDERATION
+              value: "true"
+            - name: CONTINUWUITY_ALLOW_CHECK_FOR_UPDATES
+              value: "false"
+            - name: CONTINUWUITY_ADDRESS
+              value: "0.0.0.0"
+            - name: CONTINUWUITY_NEW_USER_DISPLAYNAME_SUFFIX
+              value: ""
+            - name: ALLOW_LEGACY_MEDIA
+              value: "true"
+            # MatrixRTC / LiveKit - tells clients where to find the SFU backend.
+            # Not configured on this cluster yet: LiveKit does not run here, and
+            # there is no livekit.gregbob.net route. Enable once the SFU exists:
+            #   - name: CONTINUWUITY_MATRIX_RTC__FOCI
+            #     value: '[{ type = "livekit", livekit_service_url = "https://livekit.gregbob.net" }]'
+            #   (value MUST be TOML syntax, not JSON: figment's Env provider parses
+            #    env values as TOML; JSON stays a string and fails sequence coercion)
+          securityContext:
+            allowPrivilegeEscalation: false
+            readOnlyRootFilesystem: true
+            capabilities:
+              drop:
+                - ALL
+          ports:
+            - name: uwu-port
+              containerPort: 8080
+              protocol: TCP
+          readinessProbe:
+            tcpSocket:
+              port: 8080
+            initialDelaySeconds: 10
+            periodSeconds: 10
+          livenessProbe:
+            tcpSocket:
+              port: 8080
+            initialDelaySeconds: 30
+            periodSeconds: 30
+          volumeMounts:
+            - name: continuwuity-data
+              mountPath: /data
+            - name: continuwuity-backup
+              mountPath: /backup
+          resources:
+            limits:
+              memory: 3Gi
+            requests:
+              memory: 3Gi
+              cpu: "1.5"
+      dnsPolicy: ClusterFirst
+      restartPolicy: Always
+  selector:
+    matchLabels:
+      app: continuwuity
+  volumeClaimTemplates:
+    - metadata:
+        name: continuwuity-data
+      spec:
+        accessModes: ["ReadWriteOnce"]
+        storageClassName: local-path
+        resources:
+          requests:
+            storage: 100Gi
+    - metadata:
+        name: continuwuity-backup
+      spec:
+        accessModes: ["ReadWriteOnce"]
+        storageClassName: ceph-block
+        resources:
+          requests:
+            storage: 100Gi

--- a/clusters/cluster0/kubernetes/apps/matrix/continuwuity/app/continuwuity-well-known-route.yaml
+++ b/clusters/cluster0/kubernetes/apps/matrix/continuwuity/app/continuwuity-well-known-route.yaml
@@ -1,0 +1,20 @@
+---
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata:
+  name: continuwuity-well-known
+  namespace: matrix
+spec:
+  hostnames:
+  - gregbob.net
+  parentRefs:
+  - name: wildcard-gregbob-net
+    namespace: network
+  rules:
+  - backendRefs:
+    - name: continuwuity-service
+      port: 8080
+    matches:
+    - path:
+        type: PathPrefix
+        value: /.well-known/matrix

--- a/clusters/cluster0/kubernetes/apps/matrix/continuwuity/ks.yaml
+++ b/clusters/cluster0/kubernetes/apps/matrix/continuwuity/ks.yaml
@@ -1,0 +1,20 @@
+---
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: &app continuwuity
+  namespace: flux-system
+spec:
+  targetNamespace: matrix
+  commonMetadata:
+    labels:
+      app.kubernetes.io/name: *app
+  path: ./clusters/cluster0/kubernetes/apps/matrix/continuwuity/app/
+  prune: true
+  sourceRef:
+    kind: GitRepository
+    name: flux-system
+  wait: false
+  interval: 3m
+  retryInterval: 1m
+  timeout: 2m

--- a/clusters/cluster0/kubernetes/apps/matrix/kustomization.yaml
+++ b/clusters/cluster0/kubernetes/apps/matrix/kustomization.yaml
@@ -1,0 +1,9 @@
+---
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  # Pre Flux-Kustomizations
+  - ./namespace.yaml
+  # Flux-Kustomizations
+  - ./continuwuity/ks.yaml
+  - ./sable/ks.yaml

--- a/clusters/cluster0/kubernetes/apps/matrix/namespace.yaml
+++ b/clusters/cluster0/kubernetes/apps/matrix/namespace.yaml
@@ -1,0 +1,9 @@
+---
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: matrix
+  labels:
+    pod-security.kubernetes.io/enforce: baseline
+    pod-security.kubernetes.io/audit: baseline
+    pod-security.kubernetes.io/warn: baseline

--- a/clusters/cluster0/kubernetes/apps/matrix/sable/app/deployment.yaml
+++ b/clusters/cluster0/kubernetes/apps/matrix/sable/app/deployment.yaml
@@ -1,0 +1,98 @@
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: sable-config
+  namespace: matrix
+data:
+  config.json: |
+    {
+      "productName": "Sable",
+      "defaultHomeserver": 0,
+      "homeserverList": ["gregbob.net"],
+      "allowCustomHomeservers": true,
+      "elementCallUrl": null,
+      "disableAccountSwitcher": false,
+      "hideUsernamePasswordFields": false
+    }
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  labels:
+    app: sable
+    app.kubernetes.io/name: sable
+  name: sable
+  namespace: matrix
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: sable
+  template:
+    metadata:
+      labels:
+        app: sable
+        app.kubernetes.io/name: sable
+    spec:
+      automountServiceAccountToken: false
+      securityContext:
+        runAsNonRoot: true
+        runAsUser: 1000
+        runAsGroup: 1000
+        fsGroup: 1000
+        seccompProfile:
+          type: RuntimeDefault
+      containers:
+        - name: sable
+          image: ghcr.io/sableclient/sable:latest@sha256:b8120bb21feb64b6a3bab632c05551807cd1afca476118892cb5deb834a3ce9c
+          imagePullPolicy: Always
+          ports:
+            - name: http
+              containerPort: 8080
+              protocol: TCP
+          resources:
+            requests:
+              memory: 32Mi
+              cpu: 10m
+            limits:
+              memory: 64Mi
+          securityContext:
+            allowPrivilegeEscalation: false
+            readOnlyRootFilesystem: true
+            capabilities:
+              drop:
+                - ALL
+          volumeMounts:
+            - name: config
+              mountPath: /app/config.json
+              subPath: config.json
+              readOnly: true
+            - name: tmp
+              mountPath: /tmp
+            - name: caddy-data
+              mountPath: /data
+            - name: caddy-config
+              mountPath: /config
+          livenessProbe:
+            httpGet:
+              path: /
+              port: http
+            initialDelaySeconds: 5
+            periodSeconds: 30
+          readinessProbe:
+            httpGet:
+              path: /
+              port: http
+            initialDelaySeconds: 3
+            periodSeconds: 10
+      volumes:
+        - name: config
+          configMap:
+            name: sable-config
+        - name: tmp
+          emptyDir: {}
+        - name: caddy-data
+          emptyDir: {}
+        - name: caddy-config
+          emptyDir: {}

--- a/clusters/cluster0/kubernetes/apps/matrix/sable/app/sable-route.yaml
+++ b/clusters/cluster0/kubernetes/apps/matrix/sable/app/sable-route.yaml
@@ -1,0 +1,20 @@
+---
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata:
+  name: sable
+  namespace: matrix
+spec:
+  hostnames:
+    - sable.gregbob.net
+  parentRefs:
+    - name: wildcard-gregbob-net
+      namespace: network
+  rules:
+    - matches:
+        - path:
+            type: PathPrefix
+            value: /
+      backendRefs:
+        - name: sable-service
+          port: 8080

--- a/clusters/cluster0/kubernetes/apps/matrix/sable/app/service.yaml
+++ b/clusters/cluster0/kubernetes/apps/matrix/sable/app/service.yaml
@@ -1,0 +1,14 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: sable-service
+  namespace: matrix
+spec:
+  type: ClusterIP
+  selector:
+    app: sable
+  ports:
+    - name: http
+      port: 8080
+      protocol: TCP
+      targetPort: http

--- a/clusters/cluster0/kubernetes/apps/matrix/sable/ks.yaml
+++ b/clusters/cluster0/kubernetes/apps/matrix/sable/ks.yaml
@@ -1,0 +1,20 @@
+---
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: &app sable
+  namespace: flux-system
+spec:
+  targetNamespace: matrix
+  commonMetadata:
+    labels:
+      app.kubernetes.io/name: *app
+  path: ./clusters/cluster0/kubernetes/apps/matrix/sable/app/
+  prune: true
+  sourceRef:
+    kind: GitRepository
+    name: flux-system
+  wait: false
+  interval: 3m
+  retryInterval: 1m
+  timeout: 2m


### PR DESCRIPTION
## Summary
Ports the **matrix** namespace from the biggs.dog repo (cluster1) into this repo, using the established Flux-managed GitOps pattern:

```
clusters/cluster0/kubernetes/apps/matrix/
  kustomization.yaml          # namespace.yaml + the two app ks.yaml files
  namespace.yaml              # matrix ns (PSA baseline labels)
  continuwuity/ks.yaml        # Flux Kustomization -> continuwuity/app/
  continuwuity/app/           # StatefulSet, Service, ExternalSecret, 2x HTTPRoute
  sable/ks.yaml               # Flux Kustomization -> sable/app/
  sable/app/                  # Deployment, ConfigMap, Service, HTTPRoute
```

No central registration needed: the root Flux sync (`path: clusters/cluster0`) picks up the new namespace dir the same way it does for every other `apps/<ns>` root.

## Adaptations for this cluster (verified against live state)
| From (biggs.dog) | To (biggs-sz) |
|---|---|
| `.biggs.dog` hostnames | `.gregbob.net` |
| CONTINUWUITY_SERVER_NAME `biggs.dog` | `gregbob.net` |
| parentRef `wildcard-biggs-dog` (ns `networking`, +sectionName) | `wildcard-gregbob-net` (ns `network`, name-only like all other routes here) |
| data PVC `storageClassName: host-path` | `local-path` (no host-path SC here); backups stay `ceph-block` |
| ks.yaml `prune: false / wait: true` (migration-mode) | `prune: true / wait: false` + `targetNamespace: matrix` (repo standard) |

Kept as-is: node pin `worker-01` (node exists here), image digests, security contexts, resource limits, registration-token ExternalSecret shape.

## Deliberate omissions
- **MatrixRTC FOCI (LiveKit)**: commented out - LiveKit does not run on this cluster and there is no `livekit.gregbob.net` route. Enable once an SFU exists.
- **`network-policies/policies/apps/matrix.yaml`** (CiliumNetworkPolicy set): left out - this repo has no `network-policies/` app and no default-deny; nothing here depends on it. Happy to add it if you want the allow-lists anyway.

## Prerequisite (1Password)
An ExternalSecret references 1Password item **`continuwuity-credentials`** with fields **`token`** (registration token) and **`CONDUWUIT_EMERGENCY_PASSWORD`**. Until that item exists, the ExternalSecret will be unready (the app still boots; only token-gated registration is missing). The item in the source 1P vault would need its name/fields mirrored - or the remoteRef keys adjusted to match whatever you create.

## Validation done
- `kubectl kustomize` renders the namespace root and both app dirs cleanly
- Server-side/client-side dry-runs on the live cluster: all 10 manifests pass OpenAPI schema validation
- Zero references to the old cluster's SCs, gateways, or domain

Not merged - as requested.