### PR TITLE
[DRAFT — DO NOT MERGE] NVIDIA GPU Operator stack for future RTX 3090

### DIFF
--- a/clusters/cluster0/flux-system/sources/nvidia-repo.yaml
+++ b/clusters/cluster0/flux-system/sources/nvidia-repo.yaml
@@ -1,0 +1,9 @@
+---
+apiVersion: source.toolkit.fluxcd.io/v1
+kind: HelmRepository
+metadata:
+  name: nvidia
+  namespace: flux-system
+spec:
+  interval: 1h
+  url: https://helm.ngc.nvidia.com/nvidia

--- a/clusters/cluster0/kubernetes/apps/kube-system/nvidia-gpu-operator/app/helmrelease.yaml
+++ b/clusters/cluster0/kubernetes/apps/kube-system/nvidia-gpu-operator/app/helmrelease.yaml
@@ -1,0 +1,102 @@
+---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/fluxcd-community/flux2-schemas/main/helmrelease-helm-v2.json
+#
+# 🟡 DRAFT — see ../ks.yaml header for the full "do not merge until hardware"
+# rationale and the TODO list to work through before un-drafting this.
+#
+# Adapted from shrinedogg/biggs.dog's dreamcast/nv-gpu-operator (which targets
+# Talos + a shared/time-sliced RTX 5090). biggs-sz runs plain k3s on standard
+# Linux nodes (not Talos), so the driver/toolkit management model is
+# INVERTED from the source:
+#   - source (Talos):  driver.enabled=false, toolkit.enabled=false (Talos
+#     system extensions provide both; the operator cannot mutate the
+#     immutable Talos host).
+#   - biggs-sz (k3s):   driver.enabled=true, toolkit.enabled=true (nothing
+#     else on a standard k3s node provides the NVIDIA driver or container
+#     toolkit; the GPU Operator must manage both itself).
+#
+# nfd.enabled=false: biggs-sz already runs a standalone Node Feature Discovery
+# HelmRelease (kube-system/nfd, chart node-feature-discovery 0.18.1). Do NOT
+# let the GPU Operator install its own bundled NFD (that would run two NFD
+# masters fighting over the same node labels). This asks the operator's
+# gpu-feature-discovery subchart to attach to the EXISTING NFD instance
+# instead. VERIFY this compatibility against the live chart before un-drafting
+# (see ../ks.yaml TODO #3) -- it is asserted here from NVIDIA's documented
+# "existing NFD" deployment mode, not from a render test against 0.18.1.
+apiVersion: helm.toolkit.fluxcd.io/v2
+kind: HelmRelease
+metadata:
+  name: nvidia-gpu-operator
+  namespace: kube-system
+spec:
+  interval: 3m
+  chart:
+    spec:
+      chart: gpu-operator
+      # Same version the source biggs.dog cluster pins (v26.3.3). Re-verify
+      # current/latest at un-draft time; Renovate can take over afterward.
+      version: v26.3.3
+      sourceRef:
+        kind: HelmRepository
+        name: nvidia
+        namespace: flux-system
+  install:
+    remediation:
+      retries: 3
+  upgrade:
+    cleanupOnFail: true
+    remediation:
+      retries: 3
+  values:
+    nfd:
+      # See header note: use biggs-sz's existing standalone NFD, don't
+      # install a second one.
+      enabled: false
+    driver:
+      # k3s on standard Linux: the operator must install/manage the NVIDIA
+      # driver itself (unlike the source's Talos cluster). Confirm the target
+      # node's OS/kernel is compatible with the operator-managed driver
+      # container before enabling in production (Ubuntu/Debian standard
+      # kernels are well-supported; anything unusual needs a precompiled
+      # driver container check against NVIDIA's driver container matrix).
+      enabled: true
+    toolkit:
+      # k3s: the operator manages the NVIDIA Container Toolkit + configures
+      # containerd. Verify the k3s containerd config path
+      # (typically /var/lib/rancher/k3s/agent/etc/containerd/config.toml.tmpl
+      # for k3s, NOT the vanilla /etc/containerd/config.toml the chart
+      # defaults assume) and set toolkit.env CONTAINERD_CONFIG /
+      # CONTAINERD_SOCKET accordingly if the chart defaults don't already
+      # detect k3s. THIS IS THE #1 THING TO VALIDATE AGAINST THE LIVE NODE.
+      enabled: true
+    operator:
+      defaultRuntime: containerd
+    # Time-slicing: copied from source as a STARTING POINT ONLY. The source
+    # cluster shares one GPU between vLLM and gaming sessions (needs 2+
+    # replicas). biggs-sz has no such multi-consumer use case yet -- DECIDE
+    # the right replica count (likely 1, i.e. no slicing, until a concrete
+    # need for GPU sharing exists) before un-drafting. Left disabled by
+    # default (devicePlugin.config.create: false) until that decision is made.
+    devicePlugin:
+      config:
+        create: false
+        name: time-slicing-config
+        default: time-slicing
+        data:
+          time-slicing: |-
+            version: v1
+            sharing:
+              timeSlicing:
+                resources:
+                  - name: nvidia.com/gpu
+                    replicas: 1
+    # NOTE: the source HelmRelease also configures a custom DCGM-exporter
+    # metric profile (Xid error alerting, clocks/temps/power/PCIe/DCP
+    # metrics) plus a companion VMRule + VMServiceScrape + Grafana dashboard
+    # (dreamcast/nv-gpu-operator/app/{vmrule,vmservicescrape,grafana-dashboard}.yaml
+    # in the source repo). NOT ported here -- intentionally deferred until
+    # the base operator install is verified working on real biggs-sz
+    # hardware. Port those four files once this HelmRelease is un-drafted and
+    # confirmed healthy; they were straightforward observability additions
+    # with no source-cluster-specific assumptions besides the metric names
+    # (double-check DCGM field names against the deployed exporter version).

--- a/clusters/cluster0/kubernetes/apps/kube-system/nvidia-gpu-operator/ks.yaml
+++ b/clusters/cluster0/kubernetes/apps/kube-system/nvidia-gpu-operator/ks.yaml
@@ -1,0 +1,65 @@
+---
+# ============================================================================
+# 🟡 DRAFT — GPU stack for the RTX 3090 port (PR #38 review remediation).
+#
+# DO NOT MERGE / DO NOT REGISTER until the GPU is physically installed in a
+# biggs-sz node. This Kustomization is intentionally NOT listed in
+# kube-system/kustomization.yaml, so it is invisible to Flux's auto-discovery
+# and cannot block reconciliation of anything else in this repo.
+#
+# When the hardware lands:
+#   1. Confirm the target node, then set `operator.nodeSelector` below (or add
+#      a taint/toleration + nodeSelector to pin the operator daemonsets, once
+#      the node label is known) — DaemonSets are cluster-wide by default and
+#      will otherwise attempt to schedule (and fail cleanly, but noisily) on
+#      every node.
+#   2. Add `./nvidia-gpu-operator/ks.yaml` to kube-system/kustomization.yaml.
+#   3. Verify against the LIVE cluster (do not assume from this draft):
+#        - k3s containerd config path/socket used below is still correct for
+#          the running k3s version.
+#        - the existing standalone `nfd` HelmRelease (kube-system/nfd) is
+#          compatible with `nfd.enabled: false` here (GPU Operator's
+#          gpu-feature-discovery subchart talking to the existing NFD master
+#          instead of installing a second one) — this is NVIDIA's documented
+#          "use an existing NFD" mode but has NOT been render-tested against
+#          biggs-sz's nfd chart version (0.18.1) in this draft.
+#        - `driver.enabled: true` / `toolkit.enabled: true` are correct for
+#          plain k3s (unlike the source biggs.dog cluster, which runs Talos
+#          with the driver/toolkit provided by Talos system extensions and
+#          therefore disables both here — DO NOT copy that source pattern).
+#   4. `time-slicing.replicas: 4` was copied from source purely as a starting
+#      point (source shares one 5090 across a gaming + vLLM workload). biggs-sz
+#      has no gaming/arbiter use case yet; 1 (no slicing) or a smaller number
+#      is probably correct until a real multi-consumer need exists. DECIDE
+#      before enabling.
+#   5. This ks.yaml already sets `dependsOn: [{name: nfd}]`, matching the
+#      intel-gpu-plugin convention (biggs-sz's other GPU-adjacent device
+#      plugin). Verify the `nfd` Kustomization name still matches at
+#      un-draft time.
+# ============================================================================
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: &app nvidia-gpu-operator
+  namespace: flux-system
+spec:
+  targetNamespace: kube-system
+  commonMetadata:
+    labels:
+      app.kubernetes.io/name: *app
+  path: ./clusters/cluster0/kubernetes/apps/kube-system/nvidia-gpu-operator/app
+  prune: true
+  sourceRef:
+    kind: GitRepository
+    name: flux-system
+  wait: false
+  healthChecks:
+    - apiVersion: helm.toolkit.fluxcd.io/v2
+      kind: HelmRelease
+      name: nvidia-gpu-operator
+      namespace: kube-system
+  interval: 3m
+  retryInterval: 1m
+  timeout: 5m
+  dependsOn:
+    - name: nfd


### PR DESCRIPTION
## Summary

Drafts the NVIDIA GPU Operator stack ahead of the RTX 3090 being physically installed, per the [PR #38 review remediation plan](https://github.com/federationspace/biggs-sz/pull/38#pullrequestreview-4972225720) (Option B track — item PR-Prereq-3).

**🔴 DO NOT MERGE.** No GPU hardware exists in any biggs-sz node yet (confirmed with maintainer). This is intentionally NOT wired into Flux's auto-discovery (not listed in `kube-system/kustomization.yaml` or `flux-system/sources/kustomization.yaml`), so it has **zero effect on the live cluster** as-is — I validated that adding these files does not change the rendered output of either kustomize root.

## Why draft now instead of waiting

Writing and reviewing this ahead of time means it can merge same-day once the GPU is racked, instead of blocking that moment on a fresh authoring + review pass.

## What's here

- `flux-system/sources/nvidia-repo.yaml` — NVIDIA NGC HelmRepository (not yet registered).
- `kube-system/nvidia-gpu-operator/` — HelmRelease for the GPU Operator (chart `gpu-operator` v26.3.3), adapted from `shrinedogg/biggs.dog`'s `dreamcast/nv-gpu-operator` with the driver/toolkit model **inverted**: biggs-sz is plain k3s, not Talos, so the operator must manage the NVIDIA driver + container toolkit itself (the source disables both because Talos provides them via system extensions — copying that pattern here would leave the GPU completely unusable).
- `nfd.enabled: false` — reuses biggs-sz's existing standalone NFD (`kube-system/nfd`) instead of installing a second NFD master.
- Time-slicing config present but **disabled** (`create: false`) — the source shares one GPU across vLLM + gaming; biggs-sz has no such use case yet, needs a decision.

## Explicitly deferred / TODO before un-drafting (see inline comments)

1. **Node targeting** — which node gets the GPU; add nodeSelector/taint-toleration once known.
2. **k3s containerd config path** for the toolkit subchart — the chart's defaults assume vanilla `/etc/containerd/config.toml`; k3s uses `/var/lib/rancher/k3s/agent/etc/containerd/config.toml.tmpl`. **This is the #1 thing to verify against the live node** before enabling.
3. **`nfd.enabled: false` compatibility** with the live NFD chart version (0.18.1) — asserted from NVIDIA's documented "use existing NFD" pattern, **not render-tested**.
4. **Time-slicing replica count** — decide if/how many.
5. Source's DCGM-exporter custom metrics + VMRule + VMServiceScrape + Grafana dashboard — straightforward to port once the base install is confirmed working, deferred for now.

## Un-drafting steps (once hardware lands)

1. Set node targeting.
2. Add `./nvidia-gpu-operator/ks.yaml` to `kube-system/kustomization.yaml` and `nvidia-repo.yaml` to `flux-system/sources/kustomization.yaml`.
3. Work through the 5 TODOs above against the live cluster.
4. Convert this from Draft to Ready for review, get a real review, merge.

## Validation (offline only, no cluster mutation)

- Standalone `kubectl kustomize` render of the HelmRelease: clean.
- YAML parse of `ks.yaml` + `nvidia-repo.yaml`: clean.
- Confirmed `kube-system` (7 resources) and `flux-system/sources` (19 resources) roots render **identically** with these files present — i.e. genuinely inert until deliberately wired in.

🤖 Generated with [Claude Code](https://claude-code.nousresearch.com)