### PR TITLE
fix(media): mount RomM library at /romm/library/roms

### DIFF
--- a/clusters/cluster0/kubernetes/apps/media/romm/app/romm-deployment.yaml
+++ b/clusters/cluster0/kubernetes/apps/media/romm/app/romm-deployment.yaml
@@ -55,7 +55,7 @@ spec:
             - name: assets
               mountPath: /romm/assets
             - name: library
-              mountPath: /romm/library
+              mountPath: /romm/library/roms
               subPath: tank/media/games
           resources:
             requests:


### PR DESCRIPTION
## Summary

Fixes RomM's `Failed to create default library structure` runtime error by mounting the ROM library at RomM's expected `library/roms/` path instead of `library/`.

## Root cause

RomM expects "Structure A": `/romm/library/roms/<platform>/<game>`. The initial deploy mounted the NFS games share at `/romm/library`, so platforms landed one level too shallow (`/romm/library/NES`). RomM detected no `roms/` dir and tried to `mkdir /romm/library/roms` — which fails because the NFS export uses **root_squash** and RomM's container runs as **root** (its image requires root; it launches nginx/valkey/RQ/uvicorn as uid 0, so the sibling `PUID=1000` pattern does not apply). Result: `PermissionError: [Errno 13] ... '/romm/library/roms'`.

## Fix

Change the library `volumeMount` from `mountPath: /romm/library` to `mountPath: /romm/library/roms` (same `subPath: tank/media/games`). The existing platform folders (Dreamcast, NES, PSX, SNES, Saturn, Switch, Wii) then appear as `/romm/library/roms/<platform>` = Structure A, so RomM **detects the existing library** and never attempts the failing `mkdir`. Reads work under root_squash because the ROMs are world-readable (`755`, owned uid 1000).

## Verification

Live-tested by temporarily patching the running deployment to `/romm/library/roms` (Flux reverted it afterward, as expected — hence this PR): platforms correctly enumerated under `roms/`, and the `Failed to create default library structure` / permission errors disappeared from the logs. `kubectl kustomize apps/media` and the leaf render both exit 0.
