### PR TITLE
fix(netbird-client): binary moved to /usr/local/bin/netbird

### DIFF
--- a/clusters/cluster0/kubernetes/apps/netbird-client/client/app/daemonset.yaml
+++ b/clusters/cluster0/kubernetes/apps/netbird-client/client/app/daemonset.yaml
@@ -92,11 +92,15 @@ spec:
           # and netbirdio/netbird-server ship together). Confirm the tag exists
           # for the client image if you bump the server.
           image: netbirdio/netbird:0.74.3
-          # Image ENTRYPOINT is /go/bin/netbird (cf. the server manifest, whose
-          # entrypoint is /go/bin/netbird-server). Foreground mode runs the
-          # daemon in-process; all config comes from NB_* env vars (precedence:
+          # Binary lives at /usr/local/bin/netbird in current images (moved from
+          # /go/bin/netbird in older releases -- the old path broke the pod with
+          # "exec: /go/bin/netbird: no such file or directory"). We invoke the
+          # binary directly, bypassing the image's netbird-entrypoint.sh (which
+          # wraps `service run` + `up` in a bash supervisor): foreground mode
+          # runs the daemon in-process as a single PID, which is the k8s-native
+          # shape. All config comes from NB_* env vars (precedence:
           # env > flag > config file).
-          command: ["/go/bin/netbird"]
+          command: ["/usr/local/bin/netbird"]
           args: ["up", "--foreground-mode"]
           env:
             - name: NB_MANAGEMENT_URL
@@ -158,7 +162,7 @@ spec:
           # turns out unavailable in foreground mode, drop the probe entirely.
           readinessProbe:
             exec:
-              command: ["/go/bin/netbird", "status", "--check", "ready"]
+              command: ["/usr/local/bin/netbird", "status", "--check", "ready"]
             initialDelaySeconds: 10
             periodSeconds: 10
             failureThreshold: 6


### PR DESCRIPTION
## Problem

The netbird-client DaemonSet pod has been crashlooping since the app was added (x122 over 10h):

    exec: "/go/bin/netbird": stat /go/bin/netbird: no such file or directory

## Root cause

The manifest pinned netbirdio/netbird:0.74.3 but hardcoded the container command as /go/bin/netbird, the binary path from older NetBird image releases. Verified against the actual image:

- Config.Entrypoint: /usr/local/bin/netbird-entrypoint.sh
- NETBIRD_BIN=/usr/local/bin/netbird
- /go/bin no longer exists in the image

## Fix

- command: /usr/local/bin/netbird (readiness probe path updated too)
- Keep the existing 'up --foreground-mode' invocation: verified still supported in 0.74.3, and it keeps the single-process k8s-native shape (the image default entrypoint is a bash supervisor wrapping 'service run' + 'up')
- 'netbird status --check ready' verified still present in 0.74.3 for the readiness probe

## Verification

- kubectl kustomize clusters/cluster0/kubernetes/apps/netbird-client renders clean
- Binary path, entrypoint, env, and probe subcommand all confirmed by running the image locally (docker run netbirdio/netbird:0.74.3)
- Live pod status to be confirmed on the cluster after merge (no kubectl context on this Mac)