### PR TITLE
feat(cnpg): local-path storage + 3 instances for all clusters (phase 2/2)

### DIFF
--- a/clusters/cluster0/kubernetes/apps/databases/cnpg/databases/cnpg-gitea.yaml
+++ b/clusters/cluster0/kubernetes/apps/databases/cnpg/databases/cnpg-gitea.yaml
@@ -1,25 +1,28 @@
 apiVersion: postgresql.cnpg.io/v1
 kind: Cluster
 metadata:
-  name: cnpg-romm
+  name: cnpg-gitea
   namespace: cnpg-system
 spec:
+  # enableSuperuserAccess: true
+  # superuserSecret:
+  #   name: gitea-superuser-password
   instances: 3
   bootstrap:
     initdb:
-      database: romm
-      owner: romm
+      database: gitea
+      owner: gitea
       dataChecksums: true
       secret:
-        name: romm-user-password
+        name: gitea-user-password
   imageName: ghcr.io/cloudnative-pg/postgresql:18.1
   resources:
     requests:
       memory: 500Mi
-      cpu: 500m
+      cpu:  500m
     limits:
       memory: 500Mi
       cpu: 500m
   storage:
-    size: 10Gi
+    size: 15Gi
     storageClass: local-path

--- a/clusters/cluster0/kubernetes/apps/databases/cnpg/databases/cnpg-homarr.yaml
+++ b/clusters/cluster0/kubernetes/apps/databases/cnpg/databases/cnpg-homarr.yaml
@@ -1,25 +1,28 @@
 apiVersion: postgresql.cnpg.io/v1
 kind: Cluster
 metadata:
-  name: cnpg-romm
+  name: cnpg-homarr
   namespace: cnpg-system
 spec:
+  # enableSuperuserAccess: true
+  # superuserSecret:
+  #   name: homarr-superuser-password
   instances: 3
   bootstrap:
     initdb:
-      database: romm
-      owner: romm
+      database: homarrdb
+      owner: homarr
       dataChecksums: true
       secret:
-        name: romm-user-password
+        name: homarr-user-password
   imageName: ghcr.io/cloudnative-pg/postgresql:18.1
   resources:
     requests:
       memory: 500Mi
-      cpu: 500m
+      cpu:  500m
     limits:
       memory: 500Mi
       cpu: 500m
   storage:
-    size: 10Gi
+    size: 5Gi
     storageClass: local-path

--- a/clusters/cluster0/kubernetes/apps/databases/cnpg/databases/cnpg-renovate.yaml
+++ b/clusters/cluster0/kubernetes/apps/databases/cnpg/databases/cnpg-renovate.yaml
@@ -1,25 +1,25 @@
 apiVersion: postgresql.cnpg.io/v1
 kind: Cluster
 metadata:
-  name: cnpg-romm
+  name: cnpg-renovate
   namespace: cnpg-system
 spec:
   instances: 3
   bootstrap:
     initdb:
-      database: romm
-      owner: romm
+      database: renovate
+      owner: renovate
       dataChecksums: true
       secret:
-        name: romm-user-password
+        name: renovate-user-password
   imageName: ghcr.io/cloudnative-pg/postgresql:18.1
   resources:
     requests:
       memory: 500Mi
-      cpu: 500m
+      cpu:  500m
     limits:
       memory: 500Mi
       cpu: 500m
   storage:
-    size: 10Gi
+    size: 15Gi
     storageClass: local-path


### PR DESCRIPTION
Phase 2 of the CNPG ceph-block to local-path migration.

- Re-adds cnpg-gitea, cnpg-homarr, cnpg-renovate with storageClass: local-path and instances: 3 (removed in #43 to release the ceph-block PVCs)
- Bumps cnpg-romm 1 to 3 instances (already local-path, scales in place)
- cnpg-rreading-glasses already compliant

After merge: verify the three fresh clusters initdb, then restore the phase-1 dumps from control-00 ~/cnpg-migration (gitea 416KB, homarrdb 5.9MB, renovate 43KB) and compare row counts.