### PR TITLE
fix(netbird-client): point management URL at the real server

### DIFF
--- a/clusters/cluster0/kubernetes/apps/netbird-client/client/app/daemonset.yaml
+++ b/clusters/cluster0/kubernetes/apps/netbird-client/client/app/daemonset.yaml
@@ -1,11 +1,23 @@
 # NetBird client as a privileged hostNetwork DaemonSet.
 #
-# cluster0 is a single-node UpCloud managed cluster, so this is one pod that:
-#   1. registers as a NetBird peer against the in-cluster management server
-#      (Service netbird-server.netbird on :80), and
-#   2. acts as a NetBird NETWORK ROUTER, publishing cluster0's pod/service CIDRs
-#      to the mesh so other peers (the cluster1 node client, road-warriors) can
-#      reach cluster0 services through this node.
+# cluster0 (biggs-sz) is a 4-node cluster. This DaemonSet puts one pod per
+# node that:
+#   1. registers as a NetBird peer against the NetBird SERVER running in the
+#      biggs.dog cluster0 (public endpoint https://netbird.biggs.dog), and
+#   2. acts as a NetBird NETWORK ROUTER, publishing cluster0's pod/service
+#      CIDRs to the mesh so other peers can reach cluster0 services through
+#      these nodes.
+#
+# === Management URL: public, NOT in-cluster ===
+# The netbird server does NOT run in this cluster. It runs in the biggs.dog
+# cluster0 (repo ~/Code/biggs.dog, apps/netbird), exposed via agentgateway at
+# https://netbird.biggs.dog. An earlier revision pointed NB_MANAGEMENT_URL at
+# netbird-server.netbird.svc.cluster.local, a Service DNS name that only
+# resolves INSIDE the biggs.dog cluster; here CoreDNS answered NXDOMAIN and
+# every pod crash-looped with "failed creating connection to Management
+# Service". Management/signal gRPC is routed through that same public hostname
+# (h2c HTTPRoute with 24h stream timeouts in the biggs.dog repo), and the
+# certificate is publicly valid, so the plain public URL is correct here.
 #
 # === Why privileged + hostNetwork (and why NOT in the `netbird` namespace) ===
 # The `netbird` namespace is PSA `baseline` -- correct for the unprivileged
@@ -104,12 +116,12 @@ spec:
           args: ["up", "--foreground-mode"]
           env:
             - name: NB_MANAGEMENT_URL
-              # In-cluster combined server (management REST+gRPC, signal, relay
-              # on :80). Avoids hairpinning the control channel through the
-              # public gateway. Signal/relay/STUN are advertised by the server
-              # as the public netbird.biggs.dog host, so those still egress over
-              # the node's public IP (the node owns 87.58.147.51, so it works).
-              value: "http://netbird-server.netbird.svc.cluster.local:80"
+              # Public endpoint of the netbird server in the biggs.dog cluster.
+              # Management/signal gRPC and relay all work over this hostname
+              # (agentgateway terminates TLS, h2c to the pod; see apps/netbird
+              # in the biggs.dog repo). The node egresses via its public IP,
+              # which the server side allows. NB_ADMIN_URL below matches.
+              value: "https://netbird.biggs.dog"
             - name: NB_ADMIN_URL
               value: "https://netbird.biggs.dog"
             - name: NB_SETUP_KEY


### PR DESCRIPTION
## Problem

All 4 netbird-client pods crash-loop with:

```
dial tcp: lookup netbird-server.netbird.svc.cluster.local on 10.43.0.10:53: no such host
ERRO shared/management/client/grpc.go:134: failed creating connection to Management Service: create connection: dial context: context deadline exceeded
```

## Root cause

`NB_MANAGEMENT_URL` referenced `netbird-server.netbird.svc.cluster.local:80` — a Service that only exists inside the **biggs.dog** cluster0, where the netbird server actually runs. It has never existed in this cluster (no `netbird` namespace, no netbird Service anywhere, nothing in git history), so CoreDNS correctly answered NXDOMAIN and `netbird up --foreground-mode` exited on management-connect timeout, crash-looping every pod (39 restarts each) and failing the Flux health check.

## Fix

Point `NB_MANAGEMENT_URL` at the server's public endpoint:

```yaml
- value: "http://netbird-server.netbird.svc.cluster.local:80"
+ value: "https://netbird.biggs.dog"
```

Management/signal gRPC and relay all work over that hostname (agentgateway terminates TLS, h2c route with 24h stream timeouts — see `apps/netbird` in the biggs.dog repo). Also corrects the header comments, which were carried over from the biggs.dog context (single-node UpCloud, node owns 87.58.147.51) and never described this cluster.

## Verification

- `kubectl kustomize clusters/cluster0/kubernetes/apps/netbird-client` renders clean.
- Public endpoint pre-checked from a cluster node: `https://netbird.biggs.dog` TLS valid, `/api/` answers (management service behind gateway).
- Post-merge: Flux will roll the DaemonSet; expect `Connected` in `netbird status` and Flux KS `netbird-client` to go `True/Ready`.