### PR TITLE
fix(netbird-client): drop readiness probe, socket absent in foreground mode

### DIFF
--- a/clusters/cluster0/kubernetes/apps/netbird-client/client/app/daemonset.yaml
+++ b/clusters/cluster0/kubernetes/apps/netbird-client/client/app/daemonset.yaml
@@ -166,18 +166,15 @@ spec:
               mountPath: /dev/net/tun
             - name: state
               mountPath: /var/lib/netbird
-          # `netbird status --check ready` is the documented health check. The
-          # daemon serves the status API on its unix socket in foreground mode,
-          # so this works in-container. Readiness-only: a failing readiness
-          # gate does NOT restart the container, so even a flaky probe can't
-          # take the tunnel down -- the pod just reports NotReady. If the socket
-          # turns out unavailable in foreground mode, drop the probe entirely.
-          readinessProbe:
-            exec:
-              command: ["/usr/local/bin/netbird", "status", "--check", "ready"]
-            initialDelaySeconds: 10
-            periodSeconds: 10
-            failureThreshold: 6
+          # NOTE: no readiness/liveness probe. The natural check,
+          # `netbird status --check ready`, needs the daemon's unix socket
+          # (/var/run/netbird.sock), which foreground mode does NOT create
+          # (verified on 0.74.3: no socket in /var/run, none in
+          # /proc/net/unix across the host netns; status CLI fails with
+          # "failed to connect to daemon"). A probe that can never succeed
+          # keeps every pod NotReady forever and fails the Flux health check.
+          # Health signal is the process itself: a hung/exited daemon
+          # crash-loops the container and shows in DS status/restarts.
       volumes:
         - name: tun
           hostPath:


### PR DESCRIPTION
## Problem

After PR #45 fixed the management URL, the daemon connects fine (Management + Signal streams up, sync in ~50ms, zero restarts), but pods still never go Ready and the Flux Kustomization stays unhealthy.

## Root cause

The readiness probe runs netbird status --check ready, which needs the daemon unix socket /var/run/netbird.sock. Foreground mode does not create that socket. Verified on 0.74.3 in-cluster:

- /var/run contains no netbird.sock
- /proc/net/unix (host netns, pod is hostNetwork) shows no netbird socket at all
- netbird status via kubectl exec fails: failed to connect to daemon

A probe that can never succeed keeps every pod NotReady forever and fails the Flux health check. The manifest header already pre-authorized this exact fallback: "If the socket turns out unavailable in foreground mode, drop the probe entirely."

## Fix

Remove the readiness probe. Health signal is the process itself: an exited daemon crash-loops the container (visible in DS restarts).

## Verification

- Server-side dry-run on the cluster: daemonset.apps/netbird-client configured (server dry run)
- Renders clean; probe absent from rendered output