### PR TITLE
fix(rook-ceph): disable async discard threads to stop osd.2 crash loop

### DIFF
--- a/clusters/cluster0/kubernetes/apps/rook-ceph/rook-ceph/cluster/helmrelease.yaml
+++ b/clusters/cluster0/kubernetes/apps/rook-ceph/rook-ceph/cluster/helmrelease.yaml
@@ -25,7 +25,13 @@ spec:
       cephConfig:
         global:
           bdev_enable_discard: "true" # quote
-          bdev_async_discard_threads: "1" # quote
+          # 0 disables the async discard worker threads entirely (discards stay
+          # enabled, issued synchronously). osd.2 on worker-05 crash-looped
+          # (367 restarts, abort in KernelDevice::_discard_thread) on ceph
+          # v19.2.3; the thread life-cycle fixes landed in v19.2.4
+          # (ceph pr#65214). Safe to raise back to "1" after upgrading
+          # cephVersion.image past v19.2.3.
+          bdev_async_discard_threads: "0" # quote
           osd_class_update_on_start: "false" # quote
           device_failure_prediction_mode: local # requires mgr module
       # TODO: Enable the following options whenever deploying to a new cluster


### PR DESCRIPTION
## Problem

osd.2 on worker-05 has been crash-looping: 367 pod restarts, latest ~2.4h before inspection. The crash dump (`ceph crash info 2026-08-17T04:27:03Z_e00d...`) shows `abort()` inside `KernelDevice::_discard_thread` on ceph v19.2.3. This also pins the CephCluster CR phase at `Progressing / Processing OSD 2 on node worker-05` and keeps cluster health at HEALTH_WARN (RECENT_CRASH).

## Fix

Set `bdev_async_discard_threads: "0"` in `cephClusterSpec.cephConfig.global`. This spawns no async discard worker thread at all (the crashing code path), while `bdev_enable_discard: "true"` keeps discards flowing synchronously. The underlying thread life-cycle bugs are fixed upstream in v19.2.4 (ceph pr#65214 `blk/kernel: improve DiscardThread life cycle`, plus invalid-iterator and pending-cap fixes in 19.2.4/19.2.5); the comment block in the values notes it is safe to raise this back to "1" after the cephVersion.image upgrade past v19.2.3.

Note: the legacy `bdev_async_discard` option was removed in ceph 19.2.1, so `bdev_async_discard_threads` is the correct knob on this cluster (verified live: `ceph config get osd bdev_async_discard` = false, thread count comes solely from the threads option).

## Verification plan after merge

- Flux reconciles rook-ceph-cluster HelmRelease (v5 → v6)
- Operator restarts OSDs with the new ceph.conf; confirm with `ceph config get osd.2 bdev_async_discard_threads` = 0
- Watch osd-2 pod restart count stays flat; `ceph crash archive` the 2026-08-17 crash; health returns to HEALTH_OK (mon disk warning tracked separately)