### PR TITLE
chore: remove all CPU limits

### DIFF
--- a/clusters/cluster0/kubernetes/apps/databases/cnpg/databases/cnpg-gitea.yaml
+++ b/clusters/cluster0/kubernetes/apps/databases/cnpg/databases/cnpg-gitea.yaml
@@ -22,7 +22,6 @@ spec:
       cpu:  500m
     limits:
       memory: 500Mi
-      cpu: 500m
   storage:
     size: 15Gi
     storageClass: local-path

--- a/clusters/cluster0/kubernetes/apps/databases/cnpg/databases/cnpg-homarr.yaml
+++ b/clusters/cluster0/kubernetes/apps/databases/cnpg/databases/cnpg-homarr.yaml
@@ -22,7 +22,6 @@ spec:
       cpu:  500m
     limits:
       memory: 500Mi
-      cpu: 500m
   storage:
     size: 5Gi
     storageClass: local-path

--- a/clusters/cluster0/kubernetes/apps/databases/cnpg/databases/cnpg-renovate.yaml
+++ b/clusters/cluster0/kubernetes/apps/databases/cnpg/databases/cnpg-renovate.yaml
@@ -19,7 +19,6 @@ spec:
       cpu:  500m
     limits:
       memory: 500Mi
-      cpu: 500m
   storage:
     size: 15Gi
     storageClass: local-path

--- a/clusters/cluster0/kubernetes/apps/databases/cnpg/databases/cnpg-romm.yaml
+++ b/clusters/cluster0/kubernetes/apps/databases/cnpg/databases/cnpg-romm.yaml
@@ -19,7 +19,6 @@ spec:
       cpu: 500m
     limits:
       memory: 500Mi
-      cpu: 500m
   storage:
     size: 10Gi
     storageClass: local-path

--- a/clusters/cluster0/kubernetes/apps/databases/cnpg/databases/cnpg-rreading-glasses.yaml
+++ b/clusters/cluster0/kubernetes/apps/databases/cnpg/databases/cnpg-rreading-glasses.yaml
@@ -19,7 +19,6 @@ spec:
       cpu: 500m
     limits:
       memory: 500Mi
-      cpu: 500m
   storage:
     size: 5Gi
     storageClass: local-path

--- a/clusters/cluster0/kubernetes/apps/git-system/act_runner/app/deployment.yaml
+++ b/clusters/cluster0/kubernetes/apps/git-system/act_runner/app/deployment.yaml
@@ -44,7 +44,6 @@ spec:
               cpu: 50m
               memory: 128Mi
             limits:
-              cpu: 2000m
               memory: 2Gi
         - name: docker-dind
           image: docker:dind
@@ -62,7 +61,6 @@ spec:
               cpu: 50m
               memory: 256Mi
             limits:
-              cpu: 2000m
               memory: 4Gi
       volumes:
         - name: runner-data

--- a/clusters/cluster0/kubernetes/apps/gregbob/gregbob/art/deployment.yaml
+++ b/clusters/cluster0/kubernetes/apps/gregbob/gregbob/art/deployment.yaml
@@ -31,4 +31,3 @@ spec:
               cpu: 10m
             limits:
               memory: 128Mi
-              cpu: 250m

--- a/clusters/cluster0/kubernetes/apps/gregbob/gregbob/blog/deployment.yaml
+++ b/clusters/cluster0/kubernetes/apps/gregbob/gregbob/blog/deployment.yaml
@@ -25,7 +25,6 @@ spec:
               cpu: 10m
             limits:
               memory: 450Mi
-              cpu: 350m
       dnsPolicy: ClusterFirst
       restartPolicy: Always
   selector:

--- a/clusters/cluster0/kubernetes/apps/gregbob/gregbob/irc/deployment.yaml
+++ b/clusters/cluster0/kubernetes/apps/gregbob/gregbob/irc/deployment.yaml
@@ -53,7 +53,6 @@ spec:
               cpu: 20m
             limits:
               memory: 256Mi
-              cpu: 500m
       volumes:
         - name: config
           configMap:

--- a/clusters/cluster0/kubernetes/apps/gregbob/gregbob/landing/deployment.yaml
+++ b/clusters/cluster0/kubernetes/apps/gregbob/gregbob/landing/deployment.yaml
@@ -25,7 +25,6 @@ spec:
               cpu: 10m
             limits:
               memory: 450Mi
-              cpu: 350m
       dnsPolicy: ClusterFirst
       restartPolicy: Always
   selector:

--- a/clusters/cluster0/kubernetes/apps/gregbob/gregbob/resume/deployment.yaml
+++ b/clusters/cluster0/kubernetes/apps/gregbob/gregbob/resume/deployment.yaml
@@ -25,7 +25,6 @@ spec:
               cpu: 10m
             limits:
               memory: 450Mi
-              cpu: 350m
       dnsPolicy: ClusterFirst
       restartPolicy: Always
   selector:

--- a/clusters/cluster0/kubernetes/apps/media/epub-only/app/deployment.yaml
+++ b/clusters/cluster0/kubernetes/apps/media/epub-only/app/deployment.yaml
@@ -43,7 +43,6 @@ spec:
               cpu: 100m
               memory: 128Mi
             limits:
-              cpu: 1000m
               memory: 512Mi
           readinessProbe:
             httpGet:

--- a/clusters/cluster0/kubernetes/apps/media/jellyfin/app/jellyfin-deployment.yaml
+++ b/clusters/cluster0/kubernetes/apps/media/jellyfin/app/jellyfin-deployment.yaml
@@ -42,7 +42,6 @@ spec:
             limits:
               gpu.intel.com/i915: "1"
               memory: 4Gi
-              cpu: "4"
             requests:
               gpu.intel.com/i915: "1"
               memory: 4Gi

--- a/clusters/cluster0/kubernetes/apps/media/lidarr/app/lidarr-deployment.yaml
+++ b/clusters/cluster0/kubernetes/apps/media/lidarr/app/lidarr-deployment.yaml
@@ -39,7 +39,6 @@ spec:
               cpu: 500m
             limits:
               memory: 3Gi
-              cpu: "4"
       dnsPolicy: ClusterFirst
       restartPolicy: Always
       volumes:

--- a/clusters/cluster0/kubernetes/apps/media/ombi/app/ombi-deployment.yaml
+++ b/clusters/cluster0/kubernetes/apps/media/ombi/app/ombi-deployment.yaml
@@ -35,7 +35,6 @@ spec:
               cpu: 150m
             limits:
               memory: 1Gi
-              cpu: "2"
       dnsPolicy: ClusterFirst
       restartPolicy: Always
       volumes:

--- a/clusters/cluster0/kubernetes/apps/media/plex/app/plex-deployment.yaml
+++ b/clusters/cluster0/kubernetes/apps/media/plex/app/plex-deployment.yaml
@@ -41,7 +41,6 @@ spec:
             limits:
               gpu.intel.com/i915: "1"
               memory: 10Gi
-              cpu: "4"
             requests:
               gpu.intel.com/i915: "1"
               memory: 10Gi

--- a/clusters/cluster0/kubernetes/apps/media/prowlarr/app/prowlarr-deployment.yaml
+++ b/clusters/cluster0/kubernetes/apps/media/prowlarr/app/prowlarr-deployment.yaml
@@ -37,7 +37,6 @@ spec:
               cpu: 500m
             limits:
               memory: 2Gi
-              cpu: "2"
       dnsPolicy: ClusterFirst
       restartPolicy: Always
       volumes:

--- a/clusters/cluster0/kubernetes/apps/media/radarr/app/radarr-deployment.yaml
+++ b/clusters/cluster0/kubernetes/apps/media/radarr/app/radarr-deployment.yaml
@@ -39,7 +39,6 @@ spec:
               cpu: 500m
             limits:
               memory: 3Gi
-              cpu: "4"
       dnsPolicy: ClusterFirst
       restartPolicy: Always
       volumes:

--- a/clusters/cluster0/kubernetes/apps/media/romm/app/romm-deployment.yaml
+++ b/clusters/cluster0/kubernetes/apps/media/romm/app/romm-deployment.yaml
@@ -63,7 +63,6 @@ spec:
               cpu: 500m
             limits:
               memory: 2Gi
-              cpu: "2"
       dnsPolicy: ClusterFirst
       restartPolicy: Always
       volumes:

--- a/clusters/cluster0/kubernetes/apps/media/sabnzbd/app/sabnzbd-deployment.yaml
+++ b/clusters/cluster0/kubernetes/apps/media/sabnzbd/app/sabnzbd-deployment.yaml
@@ -44,7 +44,6 @@ spec:
               cpu: 500m
             limits:
               memory: 3Gi
-              cpu: "4"
       dnsPolicy: ClusterFirst
       restartPolicy: Always
       volumes:

--- a/clusters/cluster0/kubernetes/apps/media/sonarr/app/sonarr-deployment.yaml
+++ b/clusters/cluster0/kubernetes/apps/media/sonarr/app/sonarr-deployment.yaml
@@ -39,7 +39,6 @@ spec:
               cpu: 500m
             limits:
               memory: 3Gi
-              cpu: "4"
       dnsPolicy: ClusterFirst
       restartPolicy: Always
       volumes:

--- a/clusters/cluster0/kubernetes/apps/netbird-client/client/app/daemonset.yaml
+++ b/clusters/cluster0/kubernetes/apps/netbird-client/client/app/daemonset.yaml
@@ -159,7 +159,6 @@ spec:
               cpu: 100m
               memory: 64Mi
             limits:
-              cpu: 500m
               memory: 256Mi
           volumeMounts:
             - name: tun

--- a/clusters/cluster0/kubernetes/apps/observability/victoria-metrics/app/helmrelease.yaml
+++ b/clusters/cluster0/kubernetes/apps/observability/victoria-metrics/app/helmrelease.yaml
@@ -308,7 +308,6 @@ spec:
       spec:
         resources:
           limits:
-            cpu: 1500m
             memory: "3500Mi"
           requests:
             cpu: 500m


### PR DESCRIPTION
## Summary

Removes every CPU limit from `resources.limits` blocks across the cluster — **24 CPU limits removed across 23 files**.

Removing CPU limits avoids CFS throttling on this homelab cluster; workloads can burst on idle cores while CPU **requests** still guarantee fair scheduling shares.

## What was changed

- Deleted the `cpu:` entry from every active container/database `limits:` block.
- CPU **requests**, memory limits, and `gpu.intel.com/i915` limits are **left untouched**.
- Commented-out example blocks (victoria-*, gitea helm values, etc.) are **not** modified.
- Every affected `limits:` block still contains a `memory` (and/or GPU) entry, so no empty blocks are produced.

## Files touched (namespaces)

- `databases/cnpg`: gitea, homarr, renovate, romm, rreading-glasses (5)
- `git-system`: act_runner (2 containers)
- `gregbob`: art, blog, irc, landing, resume (5)
- `media`: epub-only, jellyfin, lidarr, ombi, plex, prowlarr, radarr, romm, sabnzbd, sonarr (10)
- `netbird-client`: client daemonset
- `observability`: victoria-metrics

## Validation

- All 23 changed files parse as valid YAML.
- Verified zero active `cpu:` entries remain under any `limits:` block.
- Diff confirms only `cpu:` lines were removed — no memory/GPU/requests lines affected.
- CRLF line endings preserved on files that used them.