### PR TITLE
chore(rook-ceph): bump charts to v1.19.9 (stage 1 of v1.20 migration)

### DIFF
--- a/clusters/cluster0/kubernetes/apps/rook-ceph/rook-ceph/cluster/helmrelease.yaml
+++ b/clusters/cluster0/kubernetes/apps/rook-ceph/rook-ceph/cluster/helmrelease.yaml
@@ -10,7 +10,7 @@ spec:
   chart:
     spec:
       chart: rook-ceph-cluster
-      version: v1.18.6
+      version: v1.19.9
       sourceRef:
         kind: HelmRepository
         name: rook-ceph

--- a/clusters/cluster0/kubernetes/apps/rook-ceph/rook-ceph/operator/helmrelease.yaml
+++ b/clusters/cluster0/kubernetes/apps/rook-ceph/rook-ceph/operator/helmrelease.yaml
@@ -11,7 +11,7 @@ spec:
   chart:
     spec:
       chart: rook-ceph
-      version: v1.18.6
+      version: v1.19.9
       sourceRef:
         kind: HelmRepository
         name: rook-ceph


### PR DESCRIPTION
## Summary

Stage 1 of 2 for bringing rook-ceph in line with the biggs.dog cluster1 layout (chart v1.20.4 + ceph-csi-operator model).

The rook v1.20 upgrade guide requires the operator to be on **at least v1.19.5** before helm-upgrading to v1.20 ("a critical update in v1.19.5 enables the helm upgrade path"). cluster0 runs v1.18.6 today, so the jump is staged: this PR is the intermediate hop, stage 2 follows separately.

## What changes

Two version lines only:

- `rook-ceph` (operator): v1.18.6 -> v1.19.9
- `rook-ceph-cluster`: v1.18.6 -> v1.19.9

No values changes. Verified against the v1.19.9 chart: `crds.enabled` and all current `csi.*` keys still exist there (they are only removed in v1.20), and neither chart ships a values schema that could reject anything.

## What to expect when this merges

- Flux upgrades the operator to v1.19.9, then the cluster chart.
- Side effect: the v1.19.9 cluster chart moves the default ceph image from **v19.2.3 to v19.2.6** (latest Squid patch), so ceph daemons do one rolling restart. This is desirable: v19.2.6 carries the OSD async-discard fix (ceph pr#65214).
- `bdev_async_discard_threads` deliberately stays `"0"` in this stage. It goes back to `"1"` in stage 2, once the cluster is verified healthy on v19.2.6 (per the note from #47).
- The v1.18-era auto-conversion already created `operatorconfig/ceph-csi-operator-config` and `driver/rook-ceph.rbd.csi.ceph.com` on the cluster (confirmed over ssh), so the CSI handover in stage 2 has its CRs in place.

## Validation

- `kubectl kustomize clusters/cluster0/kubernetes/apps/rook-ceph` renders clean.
- `helm template rook-ceph v1.19.9` with the live values: 137 resources, OK.
- `helm template rook-ceph-cluster v1.19.9` with the live values: OK; ceph image resolves to `quay.io/ceph/ceph:v19.2.6`; discard threads stay `"0"`.

## Stage 2

Stacked on this branch: chart v1.20.4, the `csi-rbac/` stage for the ceph-csi-operator ServiceAccounts, ceph image pinned to v19.2.6 (the v1.20.4 default is Tentacle v20.2.2, which would start a major ceph upgrade unguarded), discard threads re-enabled, and a VMServiceScrape for the mgr. Will be opened as a separate PR based on this branch.

Rollback: revert this PR; chart downgrade back to v1.18.6 is safe before stage 2 lands.
