### PR TITLE
feat(rook-ceph): migrate to v1.20.4 and the ceph-csi-operator model (stage 2)

### DIFF
--- a/clusters/cluster0/kubernetes/apps/rook-ceph/rook-ceph/cluster/helmrelease.yaml
+++ b/clusters/cluster0/kubernetes/apps/rook-ceph/rook-ceph/cluster/helmrelease.yaml
@@ -6,11 +6,11 @@ metadata:
   name: rook-ceph-cluster
   namespace: rook-ceph
 spec:
-  interval: 3m
+  interval: 5m
   chart:
     spec:
       chart: rook-ceph-cluster
-      version: v1.19.9
+      version: v1.20.4
       sourceRef:
         kind: HelmRepository
         name: rook-ceph
@@ -21,17 +21,23 @@ spec:
       # createPrometheusRules: true
     toolbox:
       enabled: true
+    # Pin Squid: the v1.20.4 chart default is ceph Tentacle v20.2.2, which
+    # would start a major upgrade on merge. v19.2.6 is the latest Squid and
+    # includes the OSD async-discard crash fix (ceph pr#65214, first in
+    # v19.2.4), so bdev_async_discard_threads is restored to "1" below
+    # (see PR #47). Revisit when intentionally upgrading to Tentacle.
+    cephImage:
+      repository: quay.io/ceph/ceph
+      tag: v19.2.6
     cephClusterSpec:
       cephConfig:
         global:
           bdev_enable_discard: "true" # quote
-          # 0 disables the async discard worker threads entirely (discards stay
-          # enabled, issued synchronously). osd.2 on worker-05 crash-looped
-          # (367 restarts, abort in KernelDevice::_discard_thread) on ceph
-          # v19.2.3; the thread life-cycle fixes landed in v19.2.4
-          # (ceph pr#65214). Safe to raise back to "1" after upgrading
-          # cephVersion.image past v19.2.3.
-          bdev_async_discard_threads: "0" # quote
+          # 1 is the ceph default. osd.2 on worker-05 crash-looped on
+          # v19.2.3 with 367 restarts (abort in KernelDevice::_discard_thread);
+          # the fix landed in v19.2.4 (ceph pr#65214). Pinned to v19.2.6
+          # above, so the async discard threads are re-enabled.
+          bdev_async_discard_threads: "1" # quote
           osd_class_update_on_start: "false" # quote
           device_failure_prediction_mode: local # requires mgr module
       # TODO: Enable the following options whenever deploying to a new cluster

--- a/clusters/cluster0/kubernetes/apps/rook-ceph/rook-ceph/cluster/vmservicescrape.yaml
+++ b/clusters/cluster0/kubernetes/apps/rook-ceph/rook-ceph/cluster/vmservicescrape.yaml
@@ -1,0 +1,30 @@
+---
+# Scrape the active Rook-Ceph mgr's Prometheus module into VictoriaMetrics.
+#
+# Both rook charts set monitoring.enabled: true, but that makes Rook emit
+# ServiceMonitor (monitoring.coreos.com/v1) CRs -- and the Prometheus Operator
+# CRDs are NOT installed in this cluster (kubectl get servicemonitor errors:
+# "the server doesn't have a resource type"). So Rook's ServiceMonitors never
+# take effect and NO ceph_* metrics were being ingested. This VMServiceScrape
+# bridges that gap: vmagent (observability/stack) runs selectAllByDefault=true,
+# so this is auto-discovered with no vmagent config change.
+#
+# The mgr Prometheus module (ceph mgr module enable prometheus, done by Rook
+# when monitoring.enabled=true) exposes /metrics on :9283 with the full ceph_*
+# series: ceph_health_status, ceph_cluster_total_used_bytes, ceph_pool_bytes_used,
+# ceph_osd_up, ceph_mon_quorum, ceph_pg_*, etc. The service selector targets
+# only the ACTIVE mgr (mgr_role=active), so failover doesn't double-scrape.
+apiVersion: operator.victoriametrics.com/v1beta1
+kind: VMServiceScrape
+metadata:
+  name: rook-ceph-mgr
+  namespace: rook-ceph
+spec:
+  selector:
+    matchLabels:
+      app: rook-ceph-mgr
+      rook_cluster: rook-ceph
+  endpoints:
+    - port: http-metrics
+      path: /metrics
+      interval: 30s

--- a/clusters/cluster0/kubernetes/apps/rook-ceph/rook-ceph/csi-rbac/kustomization.yaml
+++ b/clusters/cluster0/kubernetes/apps/rook-ceph/rook-ceph/csi-rbac/kustomization.yaml
@@ -1,0 +1,5 @@
+---
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - ./rbac.yaml

--- a/clusters/cluster0/kubernetes/apps/rook-ceph/rook-ceph/csi-rbac/rbac.yaml
+++ b/clusters/cluster0/kubernetes/apps/rook-ceph/rook-ceph/csi-rbac/rbac.yaml
@@ -1,0 +1,461 @@
+---
+# Ceph CSI RBD driver RBAC.
+#
+# Rook v1.20 deploys the ceph-csi-operator (operator binary only) but does NOT
+# create the per-driver ServiceAccounts/RBAC, and the ceph-csi-drivers Helm
+# chart cannot emit the short SA names this operator expects
+# (CSI_SERVICE_ACCOUNT_PREFIX is empty -> rbd-ctrlplugin-sa / rbd-nodeplugin-sa).
+# These objects are therefore managed directly here. Rule sets are taken
+# verbatim from the ceph-csi-drivers v1.0.1 chart; only object names and
+# binding subjects are set to the names the operator renders into the
+# rook-ceph.rbd.csi.ceph.com ctrlplugin Deployment and nodeplugin DaemonSet.
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: rbd-ctrlplugin-sa
+  namespace: rook-ceph
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: rbd-nodeplugin-sa
+  namespace: rook-ceph
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: rbd-ctrlplugin-cr
+rules:
+- apiGroups:
+  - ""
+  resources:
+  - secrets
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - ""
+  resources:
+  - persistentvolumes
+  verbs:
+  - get
+  - list
+  - watch
+  - create
+  - delete
+  - patch
+  - update
+- apiGroups:
+  - ""
+  resources:
+  - persistentvolumeclaims
+  verbs:
+  - get
+  - list
+  - watch
+  - update
+- apiGroups:
+  - storage.k8s.io
+  resources:
+  - storageclasses
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - ""
+  resources:
+  - events
+  verbs:
+  - list
+  - watch
+  - create
+  - update
+  - patch
+- apiGroups:
+  - storage.k8s.io
+  resources:
+  - volumeattachments
+  verbs:
+  - get
+  - list
+  - watch
+  - patch
+- apiGroups:
+  - storage.k8s.io
+  resources:
+  - volumeattachments/status
+  verbs:
+  - patch
+- apiGroups:
+  - ""
+  resources:
+  - nodes
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - storage.k8s.io
+  resources:
+  - csinodes
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - ""
+  resources:
+  - persistentvolumeclaims/status
+  verbs:
+  - patch
+- apiGroups:
+  - snapshot.storage.k8s.io
+  resources:
+  - volumesnapshots
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - snapshot.storage.k8s.io
+  resources:
+  - volumesnapshotclasses
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - snapshot.storage.k8s.io
+  resources:
+  - volumesnapshotcontents
+  verbs:
+  - get
+  - list
+  - watch
+  - patch
+  - update
+- apiGroups:
+  - snapshot.storage.k8s.io
+  resources:
+  - volumesnapshotcontents/status
+  verbs:
+  - update
+  - patch
+- apiGroups:
+  - ""
+  resources:
+  - configmaps
+  verbs:
+  - get
+- apiGroups:
+  - ""
+  resources:
+  - serviceaccounts
+  verbs:
+  - get
+- apiGroups:
+  - ""
+  resources:
+  - serviceaccounts/token
+  verbs:
+  - create
+- apiGroups:
+  - groupsnapshot.storage.k8s.io
+  resources:
+  - volumegroupsnapshotclasses
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - groupsnapshot.storage.k8s.io
+  resources:
+  - volumegroupsnapshotcontents
+  verbs:
+  - get
+  - list
+  - watch
+  - update
+  - patch
+- apiGroups:
+  - groupsnapshot.storage.k8s.io
+  resources:
+  - volumegroupsnapshotcontents/status
+  verbs:
+  - update
+  - patch
+- apiGroups:
+  - groupsnapshot.storage.openshift.io
+  resources:
+  - volumegroupsnapshotclasses
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - groupsnapshot.storage.openshift.io
+  resources:
+  - volumegroupsnapshotcontents
+  verbs:
+  - get
+  - list
+  - watch
+  - update
+  - patch
+- apiGroups:
+  - groupsnapshot.storage.openshift.io
+  resources:
+  - volumegroupsnapshotcontents/status
+  verbs:
+  - update
+  - patch
+- apiGroups:
+  - replication.storage.openshift.io
+  resources:
+  - volumegroupreplicationcontents
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - replication.storage.openshift.io
+  resources:
+  - volumegroupreplicationclasses
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - authentication.k8s.io
+  resources:
+  - tokenreviews
+  verbs:
+  - create
+- apiGroups:
+  - authorization.k8s.io
+  resources:
+  - subjectaccessreviews
+  verbs:
+  - create
+- apiGroups:
+  - cbt.storage.k8s.io
+  resources:
+  - snapshotmetadataservices
+  verbs:
+  - get
+  - list
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: rbd-nodeplugin-cr
+rules:
+- apiGroups:
+  - ""
+  resources:
+  - secrets
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - ""
+  resources:
+  - persistentvolumes
+  verbs:
+  - get
+  - list
+- apiGroups:
+  - storage.k8s.io
+  resources:
+  - volumeattachments
+  verbs:
+  - get
+  - list
+- apiGroups:
+  - ""
+  resources:
+  - configmaps
+  verbs:
+  - get
+- apiGroups:
+  - ""
+  resources:
+  - serviceaccounts
+  verbs:
+  - get
+- apiGroups:
+  - ""
+  resources:
+  - serviceaccounts/token
+  verbs:
+  - create
+- apiGroups:
+  - ""
+  resources:
+  - nodes
+  verbs:
+  - get
+- apiGroups:
+  - authentication.k8s.io
+  resources:
+  - tokenreviews
+  verbs:
+  - create
+- apiGroups:
+  - ""
+  resources:
+  - events
+  verbs:
+  - list
+  - watch
+  - create
+  - update
+  - patch
+- apiGroups:
+  - ""
+  resources:
+  - persistentvolumeclaims
+  verbs:
+  - get
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: rbd-ctrlplugin-crb
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: rbd-ctrlplugin-cr
+subjects:
+- kind: ServiceAccount
+  name: rbd-ctrlplugin-sa
+  namespace: rook-ceph
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: rbd-nodeplugin-crb
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: rbd-nodeplugin-cr
+subjects:
+- kind: ServiceAccount
+  name: rbd-nodeplugin-sa
+  namespace: rook-ceph
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: rbd-ctrlplugin-r
+  namespace: rook-ceph
+rules:
+- apiGroups:
+  - coordination.k8s.io
+  resources:
+  - leases
+  verbs:
+  - get
+  - watch
+  - list
+  - delete
+  - update
+  - create
+- apiGroups:
+  - csiaddons.openshift.io
+  resources:
+  - csiaddonsnodes
+  verbs:
+  - get
+  - watch
+  - list
+  - create
+  - update
+  - delete
+- apiGroups:
+  - ""
+  resources:
+  - pods
+  verbs:
+  - get
+- apiGroups:
+  - apps
+  resources:
+  - replicasets
+  verbs:
+  - get
+- apiGroups:
+  - apps
+  resources:
+  - deployments/finalizers
+  - daemonsets/finalizers
+  verbs:
+  - update
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: rbd-nodeplugin-r
+  namespace: rook-ceph
+rules:
+- apiGroups:
+  - csiaddons.openshift.io
+  resources:
+  - csiaddonsnodes
+  verbs:
+  - get
+  - watch
+  - list
+  - create
+  - update
+  - delete
+- apiGroups:
+  - ""
+  resources:
+  - pods
+  verbs:
+  - get
+- apiGroups:
+  - apps
+  resources:
+  - replicasets
+  verbs:
+  - get
+- apiGroups:
+  - apps
+  resources:
+  - deployments/finalizers
+  - daemonsets/finalizers
+  verbs:
+  - update
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: rbd-ctrlplugin-rb
+  namespace: rook-ceph
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: rbd-ctrlplugin-r
+subjects:
+- kind: ServiceAccount
+  name: rbd-ctrlplugin-sa
+  namespace: rook-ceph
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: rbd-nodeplugin-rb
+  namespace: rook-ceph
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: rbd-nodeplugin-r
+subjects:
+- kind: ServiceAccount
+  name: rbd-nodeplugin-sa
+  namespace: rook-ceph

--- a/clusters/cluster0/kubernetes/apps/rook-ceph/rook-ceph/ks.yaml
+++ b/clusters/cluster0/kubernetes/apps/rook-ceph/rook-ceph/ks.yaml
@@ -22,6 +22,28 @@ spec:
 apiVersion: kustomize.toolkit.fluxcd.io/v1
 kind: Kustomization
 metadata:
+  name: &app rook-ceph-csi-rbac
+  namespace: flux-system
+spec:
+  targetNamespace: rook-ceph
+  commonMetadata:
+    labels:
+      app.kubernetes.io/name: *app
+  path: ./clusters/cluster0/kubernetes/apps/rook-ceph/rook-ceph/csi-rbac
+  prune: true
+  sourceRef:
+    kind: GitRepository
+    name: flux-system
+  wait: true
+  interval: 3m
+  retryInterval: 1m
+  timeout: 2m
+  dependsOn:
+    - name: rook-ceph-operator
+---
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
   name: &app rook-ceph-cluster
   namespace: flux-system
 spec:
@@ -35,8 +57,8 @@ spec:
     kind: GitRepository
     name: flux-system
   wait: true
-  interval: 3m
+  interval: 5m
   retryInterval: 1m
-  timeout: 2m
+  timeout: 5m
   dependsOn:
     - name: rook-ceph-operator

--- a/clusters/cluster0/kubernetes/apps/rook-ceph/rook-ceph/operator/helmrelease.yaml
+++ b/clusters/cluster0/kubernetes/apps/rook-ceph/rook-ceph/operator/helmrelease.yaml
@@ -11,21 +11,22 @@ spec:
   chart:
     spec:
       chart: rook-ceph
-      version: v1.19.9
+      version: v1.20.4
       sourceRef:
         kind: HelmRepository
         name: rook-ceph
         namespace: flux-system
   values:
+    # v1.20 breaking change: CSI driver settings moved out of this chart to
+    # the ceph-csi-operator (deployed as a subchart; csi.installCsiOperator
+    # defaults to true, with csiServiceAccountPrefix set to "" by the rook
+    # chart). The old operator: section and csi.enableCephfsDriver /
+    # csi.enableLiveness-style keys no longer exist in the chart values, so
+    # they were dropped here. The RBD driver ServiceAccounts/RBAC the
+    # ceph-csi-operator expects (rbd-ctrlplugin-sa / rbd-nodeplugin-sa) are
+    # managed in ../csi-rbac.
     crds:
       enabled: true
-    csi:
-      cephFSKernelMountOptions: ms_mode=prefer-crc
-      enableCephfsDriver: false
-      enableCephfsSnapshotter: false
-      enableLiveness: true
-      # serviceMonitor:
-      #   enabled: true  # broken in v1.18.6
     enableDiscoveryDaemon: true
     monitoring:
       enabled: true


### PR DESCRIPTION
## Summary

Stage 2 of 2, stacked on #49. Merge #49 first and let the cluster settle on operator v1.19.9 + ceph v19.2.6 before merging this one. GitHub will retarget this PR to `main` automatically once #49 merges and its branch is deleted.

Ports the biggs.dog cluster1 rook-ceph layout (chart v1.20.4, ceph-csi-operator model) to cluster0, adapted for this cluster.

## What changes

**Charts**
- `rook-ceph` (operator) and `rook-ceph-cluster`: v1.19.9 -> v1.20.4

**New: `csi-rbac/` stage** (copied verbatim from cluster1)
- rook v1.20 breaking change: CSI driver settings moved out of the operator chart to the ceph-csi-operator, which the rook chart deploys as a subchart (`csi.installCsiOperator` defaults to true).
- The ceph-csi-operator cannot create its own RBD driver ServiceAccounts, so `csi-rbac/rbac.yaml` provides `rbd-ctrlplugin-sa` / `rbd-nodeplugin-sa` plus ClusterRoles/bindings (461 lines, namespace-scoped to `rook-ceph`, nothing cluster1-specific).
- `ks.yaml` becomes three stages with `dependsOn`: operator -> csi-rbac -> cluster.

**Operator values**
- Dropped keys that no longer exist in the v1.20.4 chart: `csi.enableCephfsDriver`, `csi.cephFSKernelMountOptions`, `csi.enableCephfsSnapshotter`, `csi.enableLiveness` (verified against the published chart; there is no values schema, so leaving them would be silently ignored, but dead config invites confusion).
- CSI continuity: the live cluster already has `operatorconfig/ceph-csi-operator-config` and `driver/rook-ceph.rbd.csi.ceph.com` from the v1.18 auto-conversion (confirmed over ssh), and per the v1.20 upgrade guide existing CSI settings keep working through the handover. RBD stays the only driver; cephfs stays disabled.
- `crds.enabled: true`, discovery daemon, monitoring, and resources unchanged.

**Cluster values**
- `cephImage` pinned to `quay.io/ceph/ceph:v19.2.6`. Critical: the v1.20.4 chart default is **Tentacle v20.2.2**, which would kick off a ceph major upgrade on merge. v19.2.6 is the latest Squid and matches what stage 1 rolls out.
- `bdev_async_discard_threads` back to `"1"` (ceph default): v19.2.6 includes the discard-thread crash fix (ceph pr#65214) that #47 worked around. Comment in file explains the history.
- OSD nodes/LVM devices, mon/osd resource tunings, `readAffinity`, and the `rook-ceph.gregbob.net` dashboard ingress all unchanged.

**New: `cluster/vmservicescrape.yaml`**
- Scrapes the active ceph mgr into VictoriaMetrics; the vmagent in this repo runs with `selectAllByDefault: true`, so it is picked up with no further wiring.

**Deliberately not ported from cluster1**
- `rook-ceph-route.yaml` (HTTPRoute) and `rook-ceph-auth-policy.yaml` (oauth2-proxy forward-auth): cluster0 has no oauth2-proxy/auth stack, and the dashboard is already exposed via the existing ingress.

## What to expect when this merges

- Operator helm-upgrades to v1.20.4, which deploys the ceph-csi-operator; it adopts the existing `OperatorConfig`/`Driver` CRs.
- csi-rbac applies, then the cluster chart reconciles. No ceph daemon image change in this stage (already v19.2.6 from #49), only the discard-thread config flip.
- Post-merge checks: `kubectl -n rook-ceph get pods` (ceph-csi-operator running), `kubectl get driver`, and confirm a ceph-block PVC still provisions/mounts.

## Validation

- `kubectl kustomize clusters/cluster0/kubernetes/apps/rook-ceph` renders: Namespace + 3 Flux Kustomizations.
- `helm template` of both v1.20.4 charts with these exact values succeeds; ceph-csi-operator subchart renders as part of the operator chart.
- Rendered ceph image is `quay.io/ceph/ceph:v19.2.6`; no v20 defaults leak in.

Rollback: revert this PR. The v1.20.4 -> v1.19.9 chart downgrade keeps working because the Driver CRs persist and v1.19 still honors them.
