### PR TITLE
fix(renovate): grant renovate role privileges on postgres-owned DB objects at initdb

### DIFF
--- a/clusters/cluster0/kubernetes/apps/databases/cnpg/databases/cnpg-renovate.yaml
+++ b/clusters/cluster0/kubernetes/apps/databases/cnpg/databases/cnpg-renovate.yaml
@@ -12,6 +12,23 @@ spec:
       dataChecksums: true
       secret:
         name: renovate-user-password
+      # Guard against the "objects owned by postgres" crashloop: renovate-ce
+      # connects as the `renovate` role (PGUSER=renovate), but if the schema is
+      # ever seeded/restored by the postgres superuser, the app role ends up
+      # with no privileges on its own tables and fails with
+      # `42501 insufficient_privilege` on task_queue / drizzle.__drizzle_migrations
+      # (the job worker can't dequeue and startup migrations abort). initdb makes
+      # renovate the DATABASE owner but NOT the owner of objects the superuser
+      # creates, so we also auto-grant it on anything postgres creates here, in
+      # any schema (incl. a future `drizzle`). Runs once, as postgres, in the
+      # `renovate` database at bootstrap. NOTE: forward-looking — only applies on
+      # a fresh (re)provision of this Cluster.
+      postInitApplicationSQL:
+        - ALTER SCHEMA public OWNER TO renovate;
+        - GRANT ALL ON SCHEMA public TO renovate;
+        - ALTER DEFAULT PRIVILEGES FOR ROLE postgres GRANT ALL ON TABLES TO renovate;
+        - ALTER DEFAULT PRIVILEGES FOR ROLE postgres GRANT ALL ON SEQUENCES TO renovate;
+        - ALTER DEFAULT PRIVILEGES FOR ROLE postgres GRANT ALL ON FUNCTIONS TO renovate;
   imageName: ghcr.io/cloudnative-pg/postgresql:18.1
   resources:
     requests:


### PR DESCRIPTION
## Problem

Renovate stopped opening PRs on this repo ~2 weeks ago. Root cause was in the CNPG-backed `renovate` database, not the Renovate config.

The `renovate-ce` app connects as the **`renovate`** role (`PGUSER=renovate`). CNPG's `initdb` makes `renovate` the **database** owner, but the tables and the `drizzle` migration schema were created/seeded by the **`postgres`** superuser (this DB carries `drizzle.__drizzle_migrations` history predating the current provisioning). Object ownership never passed to `renovate`, so it had **zero privileges on its own tables**.

Symptoms observed live:
- Job worker crash-looped on `ERROR: Error selecting job` → PostgreSQL **`42501 insufficient_privilege`** on `task_queue` (1,913 occurrences / 48h). No job could ever be dequeued → no PRs.
- After granting table privileges, startup then failed with **`postgres-migration-script-failed`** because `renovate` also lacked rights on `drizzle.__drizzle_migrations`.

## Fix

Add `postInitApplicationSQL` to the `cnpg-renovate` Cluster so a fresh provision:
1. Hands the `public` schema to `renovate` (`ALTER SCHEMA … OWNER TO renovate`).
2. Sets `ALTER DEFAULT PRIVILEGES FOR ROLE postgres` so `renovate` is **auto-granted** on any tables/sequences/functions the superuser creates later — in any schema, including a future `drizzle`.

```yaml
postInitApplicationSQL:
  - ALTER SCHEMA public OWNER TO renovate;
  - GRANT ALL ON SCHEMA public TO renovate;
  - ALTER DEFAULT PRIVILEGES FOR ROLE postgres GRANT ALL ON TABLES TO renovate;
  - ALTER DEFAULT PRIVILEGES FOR ROLE postgres GRANT ALL ON SEQUENCES TO renovate;
  - ALTER DEFAULT PRIVILEGES FOR ROLE postgres GRANT ALL ON FUNCTIONS TO renovate;
```

## Scope / caveats

- **Forward-looking only.** `postInitApplicationSQL` runs once at `initdb`, so this does **not** retroactively fix the existing DB. The live cluster was already remediated out-of-band (reassigned all 15 tables + sequence + the `drizzle` schema/migration table to `renovate`, restarted the deployment — the `42501` errors are gone and the app now boots and listens on :8080).
- **Not the whole story for PRs.** A separate, independent issue remains: the `gregbob-renovate` GitHub App (id `4505933`) currently has **0 installations** and sees 0 repos, so it must be installed on `federationspace/biggs-sz` (and granted administration:read, checks:write, issues:write, vulnerability_alerts:read, members:read) before PRs resume. That's an org-owner UI action, out of scope for this manifest change.

## Validation

- `kubectl kustomize` leaf render: **OK**
- YAML lint: **OK**
- Only 17 insertions; no other fields on `main` touched (`instances: 3`, `storageClass: local-path`, etc. preserved).
