### PR TITLE
fix(ai-system): switch Hermes provider from Nous Portal to OpenRouter

### DIFF
--- a/clusters/cluster0/kubernetes/apps/ai-system/hermes/app/configmap.yaml
+++ b/clusters/cluster0/kubernetes/apps/ai-system/hermes/app/configmap.yaml
@@ -8,10 +8,10 @@
 # Secrets and platform wiring are NOT here. Per the Hermes docs, the Matrix
 # adapter is driven by ENVIRONMENT VARIABLES (MATRIX_*), injected from the
 # hermes-secrets ExternalSecret + a plain MATRIX_HOMESERVER env in the
-# Deployment. The model provider key (Nous Portal API key) is seeded into
-# auth.json by the init container (see deployment.yaml) because Hermes stores
-# provider credentials in its credential pool, not as env vars. config.yaml
-# here holds only the non-secret model selection and runtime guardrails.
+# Deployment. The model provider key (OpenRouter API key) is consumed directly
+# from the OPENROUTER_API_KEY env var (injected via envFrom from hermes-secrets),
+# NOT from auth.json or a credential pool entry. config.yaml here holds only
+# the non-secret model selection and runtime guardrails.
 apiVersion: v1
 kind: ConfigMap
 metadata:
@@ -21,16 +21,16 @@ metadata:
     app.kubernetes.io/name: hermes
 data:
   config.yaml: |
-    # Model backend: Nous Portal (OpenRouter-compatible; routes to frontier
-    # models from every major lab under a single API key + credit balance).
-    # Independent of the in-cluster vLLM, which is scaled to 0 during Wolf
-    # gaming sessions. The Nous API key lives in auth.json (seeded by the init
-    # container), NOT in config.yaml or an env var.
-    # MAINTAINER-TUNABLE: pick any model from the Portal catalog; names follow
-    # the OpenRouter convention (vendor/model-id).
+    # Model backend: OpenRouter (routes to frontier models from every major
+    # lab under a single API key + credit balance). Independent of the
+    # in-cluster vLLM, which is scaled to 0 during Wolf gaming sessions.
+    # The OpenRouter API key is consumed from the OPENROUTER_API_KEY env var
+    # (injected via envFrom from hermes-secrets), NOT from config.yaml.
+    # MAINTAINER-TUNABLE: pick any model from the OpenRouter catalog; names
+    # follow the vendor/model-id convention.
     model:
       default: anthropic/claude-sonnet-4-5
-      provider: nous
+      provider: openrouter
 
     # Unattended gateway: enable the tool-loop circuit breaker the Docker docs
     # explicitly recommend for server/gateway deploys (default is off, which

--- a/clusters/cluster0/kubernetes/apps/ai-system/hermes/app/deployment.yaml
+++ b/clusters/cluster0/kubernetes/apps/ai-system/hermes/app/deployment.yaml
@@ -1,6 +1,6 @@
 ---
 # Minimal dedicated identity. No cluster RBAC: Hermes talks to Matrix, the
-# Nous Portal API, and its own PVC -- it never touches the Kubernetes API.
+# OpenRouter API, and its own PVC -- it never touches the Kubernetes API.
 apiVersion: v1
 kind: ServiceAccount
 metadata:
@@ -35,7 +35,7 @@ metadata:
   namespace: ai-system
   labels:
     app.kubernetes.io/name: hermes
-    app.kubernetes.io/version: "v2026.8.18"
+    app.kubernetes.io/version: "v2026.8.19"
 spec:
   replicas: 1
   # Recreate + RWO PVC: only one gateway process may own /opt/data at a time
@@ -49,11 +49,11 @@ spec:
     metadata:
       labels:
         app.kubernetes.io/name: hermes
-        app.kubernetes.io/version: "v2026.8.18"
+        app.kubernetes.io/version: "v2026.8.19"
     spec:
       serviceAccountName: hermes
       terminationGracePeriodSeconds: 30
-      # CPU-only workload (inference is external via Nous Portal). Do NOT pin
+      # CPU-only workload (inference is external via OpenRouter). Do NOT pin
       # nvidia.com/gpu.present -- that made other ai-system pods unschedulable.
       # Softly prefer non-GPU nodes so Hermes never competes with vLLM/gaming
       # for the GPU node's resources.
@@ -62,9 +62,9 @@ spec:
           requiredDuringSchedulingIgnoredDuringExecution:
             nodeSelectorTerms:
               - matchExpressions:
-                  - key: kubernetes.io/os
-                    operator: In
-                    values: ["linux"]
+                - key: kubernetes.io/os
+                  operator: In
+                  values: ["linux"]
           preferredDuringSchedulingIgnoredDuringExecution:
             - weight: 1
               preference:
@@ -80,10 +80,12 @@ spec:
       securityContext:
         fsGroup: 10000
       initContainers:
-        # Seed the Git-managed base config AND the Nous credential into
-        # /opt/data before the gateway starts. Overwrites config.yaml/SOUL.md/
-        # auth.json every boot (Git + 1Password win); leaves all agent-managed
-        # state (memories/, sessions/, skills/, cron/) untouched.
+        # Seed the Git-managed base config into /opt/data before the gateway
+        # starts. Overwrites config.yaml/SOUL.md every boot (Git wins); leaves
+        # all agent-managed state (memories/, sessions/, skills/, cron/)
+        # untouched. The OpenRouter API key is consumed from the
+        # OPENROUTER_API_KEY env var (via envFrom), NOT from auth.json, so the
+        # init container no longer needs to seed credentials.
         - name: seed-config
           image: docker.io/library/busybox:1.38
           imagePullPolicy: IfNotPresent
@@ -93,47 +95,13 @@ spec:
               set -eu
               cp /seed/config.yaml /data/config.yaml
               cp /seed/SOUL.md /data/SOUL.md
-
-              # Build auth.json with the Nous API key in Hermes's credential
-              # pool format. This is how `hermes auth add nous --type api-key`
-              # stores it: the key goes into access_token, base_url points at
-              # the Portal inference endpoint.
-              NOUS_KEY=$(cat /secrets/NOUS_API_KEY)
-              cat > /data/auth.json <<AUTHJSON
-              {
-                "version": 1,
-                "providers": {},
-                "credential_pool": {
-                  "nous": [{
-                    "id": "k8s-seed",
-                    "label": "1password-seed",
-                    "auth_type": "api_key",
-                    "priority": 0,
-                    "source": "manual",
-                    "access_token": "${NOUS_KEY}",
-                    "base_url": "https://inference-api.nousresearch.com/v1",
-                    "last_status": null,
-                    "last_status_at": null,
-                    "last_error_code": null,
-                    "last_error_reason": null,
-                    "last_error_message": null,
-                    "last_error_reset_at": null,
-                    "request_count": 0
-                  }]
-                }
-              }
-              AUTHJSON
-
-              echo "seeded config.yaml + SOUL.md + auth.json into /opt/data"
+              echo "seeded config.yaml + SOUL.md into /opt/data"
           volumeMounts:
             - name: seed
               mountPath: /seed
               readOnly: true
             - name: data
               mountPath: /data
-            - name: secrets
-              mountPath: /secrets
-              readOnly: true
           resources:
             requests:
               cpu: 10m
@@ -161,10 +129,10 @@ spec:
             # set explicitly). DMs always respond.
             - name: MATRIX_REQUIRE_MENTION
               value: "true"
-          # Provider key, Matrix token/allow-list, and dashboard basic-auth
-          # creds -- all from the hermes-secrets ExternalSecret. The Nous API
-          # key is consumed via auth.json (init container), not envFrom; it
-          # still gets mounted here for the Matrix and dashboard env vars.
+          # OpenRouter API key, Matrix token/allow-list, and dashboard basic-auth
+          # creds -- all from the hermes-secrets ExternalSecret via envFrom.
+          # The OpenRouter key (OPENROUTER_API_KEY) is consumed directly by
+          # Hermes's env-var credential resolution; no auth.json seeding needed.
           envFrom:
             - secretRef:
                 name: hermes-secrets
@@ -208,9 +176,6 @@ spec:
         - name: seed
           configMap:
             name: hermes-config
-        - name: secrets
-          secret:
-            secretName: hermes-secrets
         - name: data
           persistentVolumeClaim:
             claimName: hermes-data

--- a/clusters/cluster0/kubernetes/apps/ai-system/hermes/app/externalsecret.yaml
+++ b/clusters/cluster0/kubernetes/apps/ai-system/hermes/app/externalsecret.yaml
@@ -2,8 +2,8 @@
 # Hermes gateway secrets -- managed via External Secrets + 1Password.
 #
 # 1Password item required (biggs-sz vault): hermes-secrets, with fields:
-#   nous-api-key        -- Nous Portal API key (model provider; OpenRouter-
-#                          compatible, covers all models in the Portal catalog)
+#   openrouter-api-key  -- OpenRouter API key (model provider; routes to all
+#                          models in the OpenRouter catalog under a single key)
 #   matrix-access-token -- access token for the @hermes:gregbob.net bot on
 #                          continuwuity (register the bot, log in as it, copy
 #                          the token)
@@ -14,9 +14,9 @@
 #   dashboard-secret    -- random string for restart-stable dashboard sessions
 #                          (e.g. `openssl rand -hex 32`)
 #
-# The Nous API key is seeded into auth.json by the init container (Hermes reads
-# provider credentials from its credential pool, not from env vars). The Matrix
-# and dashboard secrets become env vars via envFrom in the Deployment.
+# All secrets become env vars via envFrom in the Deployment. The OpenRouter key
+# (OPENROUTER_API_KEY) is consumed directly by Hermes's env-var credential
+# resolution; no auth.json seeding is needed.
 apiVersion: external-secrets.io/v1
 kind: ExternalSecret
 metadata:
@@ -34,10 +34,8 @@ spec:
     creationPolicy: Owner
     template:
       data:
-        # Nous Portal API key -- NOT injected as an env var. The init container
-        # reads this from the mounted secret and writes it into auth.json's
-        # credential pool so Hermes can use the "nous" provider.
-        NOUS_API_KEY: "{{ .nousApiKey }}"
+        # OpenRouter API key -- consumed directly as an env var by Hermes.
+        OPENROUTER_API_KEY: "{{ .openrouterApiKey }}"
         # Matrix platform
         MATRIX_ACCESS_TOKEN: "{{ .matrixAccessToken }}"
         MATRIX_ALLOWED_USERS: "{{ .matrixAllowedUsers }}"
@@ -46,10 +44,10 @@ spec:
         HERMES_DASHBOARD_BASIC_AUTH_PASSWORD: "{{ .dashboardPass }}"
         HERMES_DASHBOARD_BASIC_AUTH_SECRET: "{{ .dashboardSecret }}"
   data:
-    - secretKey: nousApiKey
+    - secretKey: openrouterApiKey
       remoteRef:
         key: hermes-secrets
-        property: nous-api-key
+        property: openrouter-api-key
     - secretKey: matrixAccessToken
       remoteRef:
         key: hermes-secrets


### PR DESCRIPTION
## What

Switch the Hermes Agent gateway's model provider from **Nous Portal** to **OpenRouter**, fixing the "Provider authentication failed" error when interacting with `@hermes:gregbob.net` on Matrix.

## Root cause

The Nous Portal provider uses **OAuth device code** authentication. PR #69's second commit (`e83e48d`) seeded a raw Nous API key into `auth.json`'s `credential_pool` as an `api_key` type entry, but this doesn't work:

1. `PooledCredential.runtime_api_key` for the `nous` provider calls `_nous_invoke_jwt_is_usable()` on the `access_token`
2. `_decode_jwt_claims()` checks if the token has exactly 2 dots (JWT format); a raw API key is not a JWT, so it returns `{}`
3. The JWT's `scope` claim doesn't contain `inference:invoke`, so `_nous_invoke_jwt_is_usable` returns `False`
4. `runtime_api_key` returns `""` (empty string)
5. Falls through to `resolve_nous_runtime_credentials()`, which reads `providers.nous` from `auth.json`, but that's empty (the init container only wrote to `credential_pool.nous`)
6. Raises: **"Hermes is not logged into Nous Portal"**

The `NOUS_API_KEY` env var (set via `envFrom`) was also not consumed because `_seed_from_env` skips providers whose `auth_type` is not `api_key` (the Nous provider's `auth_type` is `oauth_device_code`).

## Fix

Switch to the **OpenRouter** provider, which accepts a raw API key directly from the `OPENROUTER_API_KEY` env var. This also simplifies the deployment by eliminating the `auth.json` init container seeding entirely.

### Changes

- **configmap.yaml**: `model.provider: nous` → `openrouter`; update comments
- **deployment.yaml**: remove `auth.json` seeding from init container; remove the `secrets` volume mount from the init container (no longer needed); `OPENROUTER_API_KEY` arrives via `envFrom` like the other env-var secrets
- **externalsecret.yaml**: `nous-api-key` field → `openrouter-api-key`; `NOUS_API_KEY` → `OPENROUTER_API_KEY` in the template data

## Prerequisite

The 1Password item `hermes-secrets` (biggs-sz vault) must have an `openrouter-api-key` field (was `nous-api-key`).

## Validation

- `kubectl kustomize` of the app directory: exit 0, 7 resources rendered
- No remaining references to `NOUS_API_KEY` or `nous-api-key` in the rendered output