### PR TITLE
fix(hermes): resolve provider auth via named custom provider; switch to Kimi K3

### DIFF
--- a/clusters/cluster0/kubernetes/apps/ai-system/hermes/app/configmap.yaml
+++ b/clusters/cluster0/kubernetes/apps/ai-system/hermes/app/configmap.yaml
@@ -8,10 +8,10 @@
 # Secrets and platform wiring are NOT here. Per the Hermes docs, the Matrix
 # adapter is driven by ENVIRONMENT VARIABLES (MATRIX_*), injected from the
 # hermes-secrets ExternalSecret + a plain MATRIX_HOMESERVER env in the
-# Deployment. The model provider key (Nous Portal API key) is seeded into
-# auth.json by the init container (see deployment.yaml) because Hermes stores
-# provider credentials in its credential pool, not as env vars. config.yaml
-# here holds only the non-secret model selection and runtime guardrails.
+# Deployment. The model provider is a NAMED CUSTOM provider (providers.nous)
+# that reads the Nous Portal key from the NOUS_API_KEY env var (mounted from
+# hermes-secrets via envFrom), so the secret never lives in config.yaml.
+# config.yaml here holds only the non-secret provider wiring + model selection.
 apiVersion: v1
 kind: ConfigMap
 metadata:
@@ -21,16 +21,28 @@ metadata:
     app.kubernetes.io/name: hermes
 data:
   config.yaml: |
-    # Model backend: Nous Portal (OpenRouter-compatible; routes to frontier
-    # models from every major lab under a single API key + credit balance).
-    # Independent of the in-cluster vLLM, which is scaled to 0 during Wolf
-    # gaming sessions. The Nous API key lives in auth.json (seeded by the init
-    # container), NOT in config.yaml or an env var.
+    # Model backend: Nous Portal (OpenAI-compatible; routes to frontier models
+    # from many labs under a single API key + credit balance). Independent of
+    # the in-cluster vLLM, which is scaled to 0 during Wolf gaming sessions.
+    #
+    # The provider is a named CUSTOM provider, not the built-in `nous` one:
+    # the built-in nous path requires an OAuth-minted agent_key (invoke JWT),
+    # which a statically-seeded API key never satisfies, so it failed with
+    # "not logged into Nous Portal". A custom provider consumes a static API
+    # key directly (chat_completions). key_env points at the NOUS_API_KEY env
+    # var (from hermes-secrets via envFrom); the key is NOT stored here.
     # MAINTAINER-TUNABLE: pick any model from the Portal catalog; names follow
     # the OpenRouter convention (vendor/model-id).
     model:
-      default: anthropic/claude-sonnet-4-5
+      default: moonshotai/kimi-k3
       provider: nous
+
+    providers:
+      nous:
+        name: nous
+        base_url: https://inference-api.nousresearch.com/v1
+        key_env: NOUS_API_KEY
+        api_mode: chat_completions
 
     # Unattended gateway: enable the tool-loop circuit breaker the Docker docs
     # explicitly recommend for server/gateway deploys (default is off, which

--- a/clusters/cluster0/kubernetes/apps/ai-system/hermes/app/deployment.yaml
+++ b/clusters/cluster0/kubernetes/apps/ai-system/hermes/app/deployment.yaml
@@ -162,9 +162,10 @@ spec:
             - name: MATRIX_REQUIRE_MENTION
               value: "true"
           # Provider key, Matrix token/allow-list, and dashboard basic-auth
-          # creds -- all from the hermes-secrets ExternalSecret. The Nous API
-          # key is consumed via auth.json (init container), not envFrom; it
-          # still gets mounted here for the Matrix and dashboard env vars.
+          # creds -- all from the hermes-secrets ExternalSecret, injected as
+          # env vars. NOUS_API_KEY is read by the named custom provider's
+          # `key_env` in config.yaml (no auth.json seeding). MATRIX_* and
+          # HERMES_DASHBOARD_BASIC_AUTH_* are consumed directly by Hermes.
           envFrom:
             - secretRef:
                 name: hermes-secrets

--- a/clusters/cluster0/kubernetes/apps/ai-system/hermes/app/externalsecret.yaml
+++ b/clusters/cluster0/kubernetes/apps/ai-system/hermes/app/externalsecret.yaml
@@ -14,9 +14,10 @@
 #   dashboard-secret    -- random string for restart-stable dashboard sessions
 #                          (e.g. `openssl rand -hex 32`)
 #
-# The Nous API key is seeded into auth.json by the init container (Hermes reads
-# provider credentials from its credential pool, not from env vars). The Matrix
-# and dashboard secrets become env vars via envFrom in the Deployment.
+# The Nous API key is consumed via the NOUS_API_KEY env var (envFrom below):
+# config.yaml declares a named custom provider with key_env: NOUS_API_KEY, so
+# Hermes reads it from the environment, not from auth.json. The Matrix and
+# dashboard secrets likewise become env vars via envFrom in the Deployment.
 apiVersion: external-secrets.io/v1
 kind: ExternalSecret
 metadata:
@@ -34,9 +35,9 @@ spec:
     creationPolicy: Owner
     template:
       data:
-        # Nous Portal API key -- NOT injected as an env var. The init container
-        # reads this from the mounted secret and writes it into auth.json's
-        # credential pool so Hermes can use the "nous" provider.
+        # Nous Portal API key -- injected as the NOUS_API_KEY env var and read
+        # by Hermes via the named custom provider's `key_env: NOUS_API_KEY`
+        # (see configmap.yaml). No auth.json seeding is involved.
         NOUS_API_KEY: "{{ .nousApiKey }}"
         # Matrix platform
         MATRIX_ACCESS_TOKEN: "{{ .matrixAccessToken }}"


### PR DESCRIPTION
## Problem

Messaging `@hermes:gregbob.net` in a Matrix channel returned **`Provider authentication failed`**. The failure is in the **LLM provider (Nous Portal)**, not Matrix; the bot's gateway received and tried to answer the message, then emitted the canned provider-auth error.

## Root cause

Confirmed against the running gateway's bundled source (`hermes_cli/runtime_provider.py`, v0.20.5) and live state.

The init container seeds the Nous key into `credential_pool.nous` as a **static `api_key`** and leaves `providers: {}` empty. But the built-in `nous` provider does not accept a static pool key: its pool path requires an OAuth-minted **`agent_key`** (a short-lived invoke JWT). `_agent_key_is_usable()` fails for the static key, so the pool is skipped and resolution falls through to `resolve_nous_runtime_credentials()`, which reads the **OAuth** state `providers["nous"]`. With that empty, it raises `AuthError("Hermes is not logged into Nous Portal.")`.

So the previous design (PR #69) was structurally unable to authenticate a statically-seeded key against the built-in `nous` provider.

Separately, the configured model `anthropic/claude-sonnet-4-5` is **not present** in the current Nous Portal catalog: a live `GET /v1/models` (key authenticates, HTTP 200, 373 models) does not list it, and `POST /v1/chat/completions` returned **HTTP 404 "Model not found."**

## Fix (Option A)

Declare a **named custom provider** that reads the key from the `NOUS_API_KEY` env var via `key_env`:

```yaml
model:
  default: moonshotai/kimi-k3
  provider: nous

providers:
  nous:
    name: nous
    base_url: https://inference-api.nousresearch.com/v1
    key_env: NOUS_API_KEY
    api_mode: chat_completions
```

A named custom provider consumes a static API key directly (no OAuth `agent_key` required) and uses `chat_completions`, which the Nous endpoint serves. The key is read from the `NOUS_API_KEY` env var (mounted from the `hermes-secrets` ExternalSecret via the existing `envFrom`), so the secret stays out of `config.yaml` and **no `auth.json` seed change is required**.

Also switches the default model to **`moonshotai/kimi-k3`** (confirmed present in the Portal catalog).

## Changes

- `configmap.yaml`: switch `model.default` to `moonshotai/kimi-k3`; add the `providers.nous` named custom provider block (`base_url`, `key_env: NOUS_API_KEY`, `api_mode: chat_completions`); updated comments.
- `externalsecret.yaml`: comment-only update (key is now consumed via env var + `key_env`, not the auth.json seed). No field or 1Password mapping changes.
- `deployment.yaml`: comment-only update on the `envFrom` block. No spec changes.

## Verification

- Embedded `config.yaml` renders and parses cleanly (PyYAML); assertions confirm `model.default=moonshotai/kimi-k3`, `model.provider=nous`, and the `providers.nous` block fields.
- Live `GET /v1/models` with the key returns HTTP 200 and includes `moonshotai/kimi-k3`.
- No changes to the secret data, RBAC, probes, or resource wiring.

## Note

The init container's `auth.json` `credential_pool.nous` seed is now unused by this provider path and left in place (harmless); it can be removed in a follow-up if desired. Flux reconciles on merge to `main`.
