### PR TITLE
fix(hermes): use provider 'custom:nous' not bare 'nous'

### DIFF
--- a/clusters/cluster0/kubernetes/apps/ai-system/hermes/app/configmap.yaml
+++ b/clusters/cluster0/kubernetes/apps/ai-system/hermes/app/configmap.yaml
@@ -35,7 +35,11 @@ data:
     # the OpenRouter convention (vendor/model-id).
     model:
       default: moonshotai/kimi-k3
-      provider: nous
+      # "custom:nous" (not bare "nous"): bare "nous" is shadowed by the built-in
+      # nous provider (which demands an OAuth agent_key and fails with "not
+      # logged in"). The "custom:<name>" form resolves to the providers.nous
+      # block below and consumes the static NOUS_API_KEY via chat_completions.
+      provider: custom:nous
 
     providers:
       nous:


### PR DESCRIPTION
## Problem

Follow-up to #78. After that PR merged and the gateway restarted, messaging the bot **still** returned `Provider authentication failed`. The live `gateway.log` showed the same `Primary provider auth failed: Hermes is not logged into Nous Portal.` on the new pod.

## Root cause

`model.provider: nous` (bare name) is **shadowed by Hermes's built-in `nous` provider**. In `_get_named_custom_provider`, the built-in shadow check returns `None` whenever `resolve_provider(name) == name` — and `resolve_provider("nous") == "nous"`. So the named custom `providers.nous` block was never matched, and resolution fell through to the built-in OAuth path, which demands an `agent_key` (invoke JWT) and fails for a static API key.

## Fix

Set `model.provider: custom:nous`. The `custom:<name>` form bypasses the shadow check and resolves the `providers.nous` block as a named custom provider, consuming the static `NOUS_API_KEY` via `chat_completions`.

Verified live on the running pod:

```
resolve_runtime_provider("custom:nous") ->
  provider=custom
  api_mode=chat_completions
  base_url=https://inference-api.nousresearch.com/v1
  api_key=<from NOUS_API_KEY, len 40>
  source=custom_provider:nous
```

Only `configmap.yaml` changes: the `model.provider` value plus an explanatory comment. Requires a pod restart to re-seed `config.yaml` (ConfigMap is applied at boot by the init container).
